### PR TITLE
feat(ssh): generate an Ed25519 keypair from the cipher editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Clavix are documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Generate an Ed25519 SSH key from the cipher editor.** When you
+  open a new SSH-key cipher and the private-key field is still empty,
+  a "Générer une clé Ed25519" button shows up above the textarea —
+  one click runs `ssh_key::PrivateKey::random` server-side and fills
+  privateKey + publicKey + keyFingerprint with a fresh OpenSSH PEM,
+  ssh-ed25519 line and SHA-256 fingerprint. The key is generated
+  in the Rust process, never touches disk, and lands directly in
+  the cipher (which is then encrypted under the master key like any
+  other field). RSA generation can come later as an algorithm
+  parameter; users with infra requiring RSA can paste an existing
+  key for now. New Tauri command `generate_ssh_key`.
+
 ## [0.1.18] — 2026-04-26
 
 ### Added

--- a/messages/en.json
+++ b/messages/en.json
@@ -104,6 +104,9 @@
   "ssh_passphrase_wrong": "Wrong passphrase.",
   "ssh_passphrase_verify": "Decrypt",
   "ssh_passphrase_hint": "The passphrase is not kept — the key will be stored decrypted inside the vault, the same way Bitwarden Desktop does.",
+  "ssh_generate_action": "Generate an Ed25519 key",
+  "ssh_generate_running": "Generating…",
+  "ssh_generate_hint": "Creates a fresh Ed25519 keypair on the fly. Or paste an existing key below.",
 
   "import_label": "Import (KeePassXC CSV)",
   "import_title": "Import from KeePassXC",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -104,6 +104,9 @@
   "ssh_passphrase_wrong": "Phrase de passe incorrecte.",
   "ssh_passphrase_verify": "Déchiffrer",
   "ssh_passphrase_hint": "La phrase de passe n'est pas conservée — la clé sera stockée déchiffrée dans le coffre, comme le fait Bitwarden Desktop.",
+  "ssh_generate_action": "Générer une clé Ed25519",
+  "ssh_generate_running": "Génération…",
+  "ssh_generate_hint": "Génère une nouvelle paire Ed25519 à la volée. Sinon, collez une clé existante ci-dessous.",
 
   "import_label": "Importer (CSV KeePassXC)",
   "import_title": "Importer depuis KeePassXC",

--- a/src-tauri/src/commands/ssh.rs
+++ b/src-tauri/src/commands/ssh.rs
@@ -159,6 +159,43 @@ pub fn decrypt_ssh_private_key(
     })
 }
 
+/// Generate a fresh Ed25519 SSH keypair, returning the canonical
+/// OpenSSH-format private key, the public-key line, and the SHA-256
+/// fingerprint. Same shape as `decrypt_ssh_private_key` so the editor
+/// can drop the result straight into its sshKey state.
+///
+/// Ed25519 only for now: it's the modern default (`ssh-keygen` picks
+/// it by default since OpenSSH 9.5), 256-bit equivalent security with
+/// 32-byte keys, generation is essentially instantaneous. RSA support
+/// can ship later as a separate algorithm parameter — until then,
+/// users with infra that requires RSA can paste an existing key.
+#[tauri::command]
+pub fn generate_ssh_key() -> Result<DecryptedSshKey> {
+    use ssh_key::{Algorithm, HashAlg, LineEnding, PrivateKey};
+
+    let mut rng = rand::thread_rng();
+    let pk = PrivateKey::random(&mut rng, Algorithm::Ed25519).map_err(|e| Error::Crypto {
+        reason: format!("generate ed25519 ssh key: {e}"),
+    })?;
+
+    let private_pem = pk
+        .to_openssh(LineEnding::LF)
+        .map_err(|e| Error::Crypto {
+            reason: format!("encode generated private key: {e}"),
+        })?
+        .to_string();
+    let public_pem = pk.public_key().to_openssh().map_err(|e| Error::Crypto {
+        reason: format!("encode generated public key: {e}"),
+    })?;
+    let fingerprint = pk.fingerprint(HashAlg::Sha256).to_string();
+
+    Ok(DecryptedSshKey {
+        private_key: private_pem,
+        public_key: public_pem,
+        key_fingerprint: fingerprint,
+    })
+}
+
 #[cfg(test)]
 mod decrypt_tests {
     use super::*;
@@ -183,6 +220,41 @@ mod decrypt_tests {
         // Truncated mid-header — must not panic, must return parse error.
         let res = decrypt_ssh_private_key("-----BEGIN OPENSSH PRIVATE KEY-----\n".into(), None);
         assert!(matches!(res, Err(Error::Crypto { .. })));
+    }
+}
+
+#[cfg(test)]
+mod generate_tests {
+    use super::*;
+
+    #[test]
+    fn generated_key_round_trips_through_decrypt_command() {
+        // Fresh Ed25519 → returned PEM is unencrypted, so feeding it
+        // back through decrypt_ssh_private_key (no passphrase) gives
+        // a stable result. Catches regressions where the encoder and
+        // parser disagree on the wire format.
+        let gen = generate_ssh_key().expect("generate ed25519");
+        assert!(gen.public_key.starts_with("ssh-ed25519 "));
+        assert!(gen.key_fingerprint.starts_with("SHA256:"));
+        assert!(gen.private_key.contains("BEGIN OPENSSH PRIVATE KEY"));
+        assert!(!gen.private_key.contains("ENCRYPTED"));
+
+        let parsed = decrypt_ssh_private_key(gen.private_key.clone(), None)
+            .expect("freshly generated key parses back");
+        assert_eq!(parsed.public_key, gen.public_key);
+        assert_eq!(parsed.key_fingerprint, gen.key_fingerprint);
+    }
+
+    #[test]
+    fn two_calls_produce_different_keys() {
+        // Sanity check that the RNG is actually being consumed —
+        // a wedged generator that returned a constant key would
+        // be a serious zero-day (and a hilarious test failure).
+        let a = generate_ssh_key().unwrap();
+        let b = generate_ssh_key().unwrap();
+        assert_ne!(a.key_fingerprint, b.key_fingerprint);
+        assert_ne!(a.private_key, b.private_key);
+        assert_ne!(a.public_key, b.public_key);
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -96,6 +96,7 @@ pub fn run() {
             commands::ssh::stop_ssh_agent,
             commands::ssh::ssh_agent_status,
             commands::ssh::decrypt_ssh_private_key,
+            commands::ssh::generate_ssh_key,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/CipherEditor.svelte
+++ b/src/lib/CipherEditor.svelte
@@ -154,6 +154,14 @@
   let sshPassphrasePrompt = $state(false);
   let sshPassphraseError = $state<string | null>(null);
 
+  // SSH key generation (create mode only) — calls into the Rust
+  // `generate_ssh_key` command which produces a fresh Ed25519 keypair
+  // via ssh_key::PrivateKey::random and returns the canonical OpenSSH
+  // PEM + ssh-ed25519 line + SHA-256 fingerprint, which we drop straight
+  // into the bound state. Mirrors Bitwarden Desktop's "generate" button
+  // in the SSH cipher editor.
+  let sshGenerating = $state(false);
+
   const orgCollections = $derived(
     organizationId ? collections.filter((c) => c.organizationId === organizationId) : [],
   );
@@ -180,8 +188,25 @@
       sshPassphrase = "";
       sshPassphrasePrompt = false;
       sshPassphraseError = null;
+      sshGenerating = false;
     }
   });
+
+  async function handleGenerateSshKey() {
+    if (sshGenerating) return;
+    sshGenerating = true;
+    error = null;
+    try {
+      const fresh = await api.generateSshKey();
+      sshKey.privateKey = fresh.privateKey;
+      sshKey.publicKey = fresh.publicKey;
+      sshKey.keyFingerprint = fresh.keyFingerprint;
+    } catch (e) {
+      error = (e as Error).message ?? String(e);
+    } finally {
+      sshGenerating = false;
+    }
+  }
 
   function tauriCode(e: unknown): string | null {
     if (e && typeof e === "object" && "code" in e) {
@@ -525,6 +550,19 @@
             </label>
           </div>
         {:else if cipherType === 5}
+          {#if mode === "create" && sshKey.privateKey.trim().length === 0}
+            <div class="ssh-generate-row">
+              <button
+                type="button"
+                class="ssh-generate-btn"
+                onclick={handleGenerateSshKey}
+                disabled={sshGenerating}
+              >
+                {sshGenerating ? m.ssh_generate_running() : m.ssh_generate_action()}
+              </button>
+              <small class="ssh-generate-hint">{m.ssh_generate_hint()}</small>
+            </div>
+          {/if}
           <label>
             {m.detail_field_private_key()}
             <textarea
@@ -666,6 +704,22 @@
   .ssh-private-key {
     font-family: ui-monospace, monospace;
     font-size: 0.82rem;
+  }
+
+  .ssh-generate-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 0.25rem;
+  }
+
+  .ssh-generate-btn {
+    align-self: flex-start;
+  }
+
+  .ssh-generate-hint {
+    color: var(--color-muted, #888);
+    font-size: 0.78rem;
   }
 
   .ssh-passphrase-hint {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -139,4 +139,6 @@ export const api = {
 
   decryptSshPrivateKey: (privateKey: string, passphrase: string | null) =>
     invoke<DecryptedSshKey>("decrypt_ssh_private_key", { privateKey, passphrase }),
+
+  generateSshKey: () => invoke<DecryptedSshKey>("generate_ssh_key"),
 };


### PR DESCRIPTION
## Summary

- New Tauri command \`generate_ssh_key\` that produces a fresh Ed25519 keypair via \`ssh_key::PrivateKey::random\` and returns the same shape as \`decrypt_ssh_private_key\` (privateKey PEM + publicKey line + SHA-256 fingerprint).
- "Générer une clé Ed25519" button in the SSH section of the cipher editor — visible only in create mode when the private-key field is empty, so it can't clobber a key the user is in the middle of pasting.
- Mirrors Bitwarden Desktop's "generate" button. Ed25519 only for v1; RSA generation can come later behind an algorithm parameter.

## Test plan

- [ ] Local: \`pnpm tauri dev\`, create a new SSH cipher, click "Générer une clé Ed25519", confirm the three fields populate with a valid OpenSSH PEM, an \`ssh-ed25519 ...\` line and a \`SHA256:...\` fingerprint, and the button disappears once filled.
- [ ] Save the cipher and confirm \`start_ssh_agent\` exposes the generated key (\`ssh-add -l\` shows the new fingerprint).
- [ ] CI: \`cargo test --lib\` covers \`generate_ssh_key\` round-tripping back through \`decrypt_ssh_private_key\` + the two-keys-differ sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)