### PR TITLE
feat(folders): cascade rename and delete from sidebar

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -218,6 +218,7 @@
   "folder_action_rename": "Rename",
   "folder_action_delete": "Delete",
   "folder_delete_confirm": "Delete folder “{name}”? {count} item(s) will be detached (not deleted) and appear under “All items”.",
+  "folder_delete_confirm_cascade": "Delete “{name}” and {subCount} sub-folder(s)? {itemCount} item(s) will be detached (not deleted) and appear under “All items”.",
 
   "items_title": "Items",
   "items_search_placeholder": "Search an item… (/ or Ctrl+F)",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -218,6 +218,7 @@
   "folder_action_rename": "Renommer",
   "folder_action_delete": "Supprimer",
   "folder_delete_confirm": "Supprimer le dossier « {name} » ? {count} item(s) seront détaché(s) (pas supprimé(s)) et apparaîtront dans « Tous les items ».",
+  "folder_delete_confirm_cascade": "Supprimer « {name} » ainsi que {subCount} sous-dossier(s) ? {itemCount} item(s) seront détaché(s) (pas supprimé(s)) et apparaîtront dans « Tous les items ».",
 
   "items_title": "Items",
   "items_search_placeholder": "Rechercher un item… (/ ou Ctrl+F)",

--- a/src-tauri/src/commands/move_share.rs
+++ b/src-tauri/src/commands/move_share.rs
@@ -111,6 +111,48 @@ pub async fn move_folder_path(
         compute_new_folder_base(&source_path, target_parent_path.as_deref())
             .map_err(|reason| Error::Storage { reason })?;
 
+    apply_folder_path_rename(state, &source_path, &new_base).await
+}
+
+/// Cascade-rename a folder path. Behaves like `move_folder_path` except
+/// the caller hands in the *new* path verbatim instead of a target
+/// parent — used by the sidebar's right-click rename when the clicked
+/// node may be a synthetic parent (`work` showing only because
+/// `work/projects` exists). The same `plan_folder_renames` machinery
+/// then rewrites every folder whose name equals or sits under
+/// `source_path`.
+#[tauri::command]
+pub async fn rename_folder_path(
+    state: State<'_, AppState>,
+    source_path: String,
+    new_path: String,
+) -> Result<()> {
+    ensure_fresh_tokens(&state).await?;
+
+    let source = source_path.trim().trim_matches('/').to_string();
+    let new_base = new_path.trim().trim_matches('/').to_string();
+    if source.is_empty() || new_base.is_empty() {
+        return Err(Error::Storage {
+            reason: "folder path cannot be empty".into(),
+        });
+    }
+    if new_base == source {
+        return Ok(());
+    }
+    if new_base.starts_with(&format!("{source}/")) {
+        return Err(Error::Storage {
+            reason: "cannot rename a folder into one of its descendants".into(),
+        });
+    }
+
+    apply_folder_path_rename(state, &source, &new_base).await
+}
+
+async fn apply_folder_path_rename(
+    state: State<'_, AppState>,
+    source_path: &str,
+    new_base: &str,
+) -> Result<()> {
     let (client, access_token, operations) = {
         let guard = state.session.lock();
         let session = guard.as_ref().ok_or(Error::NotAuthenticated)?;
@@ -140,7 +182,7 @@ pub async fn move_folder_path(
             };
             decrypted.push((f.id.clone(), name));
         }
-        let plan = plan_folder_renames(&decrypted, &source_path, &new_base);
+        let plan = plan_folder_renames(&decrypted, source_path, new_base);
         if plan.is_empty() {
             return Err(Error::Storage {
                 reason: format!("no folder matches path '{source_path}'"),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,6 +97,7 @@ pub fn run() {
             commands::move_share::move_cipher_to_folder,
             commands::move_share::move_cipher_to_collection,
             commands::move_share::move_folder_path,
+            commands::move_share::rename_folder_path,
             commands::move_share::share_cipher_to_collection,
             commands::audit::audit_vault_passwords,
             commands::ssh::start_ssh_agent,

--- a/src/lib/VaultSidebar.svelte
+++ b/src/lib/VaultSidebar.svelte
@@ -3,7 +3,7 @@
   import Icon, { type IconName } from "./Icon.svelte";
   import { canDropFolderOn, isCipherDroppable, isFolderDropTarget } from "./drag";
   import type { DragController } from "./drag.svelte";
-  import { folderPathFromKey } from "./tree";
+  import { collectFolderIds, folderPathFromKey } from "./tree";
   import type { CipherIndex } from "./tree";
   import type { Locale, QuickFilter, SyncSummary, TreeNode } from "./types";
 
@@ -25,8 +25,8 @@
     onMoveCipherToFolder: (cipherId: string, folderId: string | null) => Promise<void>;
     onMoveCipherToCollection: (cipherId: string, collectionId: string) => Promise<void>;
     onMoveFolderPath: (source: string, targetParent: string | null) => Promise<void>;
-    onDeleteFolder: (folderId: string) => Promise<void>;
-    onRenameFolder: (folderId: string, name: string) => Promise<void>;
+    onDeleteFolder: (folderIds: string[]) => Promise<void>;
+    onRenameFolder: (sourcePath: string, newPath: string) => Promise<void>;
   };
 
   let {
@@ -64,7 +64,13 @@
   let renameValue = $state("");
 
   function openContextMenu(event: MouseEvent, node: TreeNode) {
-    if (!node.folderId) return;
+    // Synthetic parents (folderId === null because they only exist
+    // as path containers for nested folders like `work` from
+    // `work/projects`) still get the menu. Both rename and delete
+    // operate on the path: the Rust side cascades through every
+    // descendant by prefix match, so the user does not need to know
+    // whether the node is real or synthesised.
+    if (node.kind !== "folder") return;
     event.preventDefault();
     menuNode = node;
     menuX = event.clientX;
@@ -77,17 +83,35 @@
 
   async function confirmDelete() {
     const node = menuNode;
-    if (!node?.folderId) return;
+    if (!node) return;
     closeContextMenu();
-    const ok = window.confirm(
-      m.folder_delete_confirm({ name: node.label, count: String(node.itemCount) }),
-    );
+
+    // Collect every real folder id under this node (the node itself
+    // included when it has one). Synthetic parents have folderId ===
+    // null, so deleting them is purely a cascade through descendants.
+    const ids = new Set<string>();
+    collectFolderIds(node, ids);
+    if (ids.size === 0) return;
+
+    const path = folderPathFromKey(node.key) ?? node.label;
+    const message =
+      ids.size === 1 && node.folderId
+        ? m.folder_delete_confirm({ name: path, count: String(node.itemCount) })
+        : m.folder_delete_confirm_cascade({
+            name: path,
+            // `subCount` excludes the clicked node when it is a real
+            // folder, so the dialog reads naturally: "delete `work`
+            // and 2 sub-folders" rather than counting `work` twice.
+            subCount: String(node.folderId ? ids.size - 1 : ids.size),
+            itemCount: String(node.itemCount),
+          });
+    const ok = window.confirm(message);
     if (!ok) return;
-    await onDeleteFolder(node.folderId);
+    await onDeleteFolder(Array.from(ids));
   }
 
   function startRename() {
-    if (!menuNode?.folderId) return;
+    if (!menuNode || menuNode.kind !== "folder") return;
     renamingNode = menuNode;
     renameValue = menuNode.label;
     closeContextMenu();
@@ -96,11 +120,22 @@
   async function commitRename(event: Event) {
     event.preventDefault();
     const node = renamingNode;
-    if (!node?.folderId) return;
+    if (!node) return;
     const next = renameValue.trim();
     renamingNode = null;
     if (next.length === 0 || next === node.label) return;
-    await onRenameFolder(node.folderId, next);
+    // Compose the new path by replacing the last segment of the old
+    // path with the user's input, so renaming a node nested at
+    // `work/projects` to `archive` lands on `work/archive` (rather
+    // than re-rooting). Synthetic parents go through the exact same
+    // path because the Rust side cascades on prefix match.
+    const oldPath = folderPathFromKey(node.key);
+    if (!oldPath) return;
+    const segments = oldPath.split("/");
+    segments[segments.length - 1] = next;
+    const newPath = segments.join("/");
+    if (newPath === oldPath) return;
+    await onRenameFolder(oldPath, newPath);
   }
 
   function cancelRename() {
@@ -349,7 +384,7 @@
           draggable={node.kind === "folder"}
           onclick={() => onSelectNode(node.key)}
           oncontextmenu={(e) =>
-            node.kind === "folder" && node.folderId ? openContextMenu(e, node) : undefined}
+            node.kind === "folder" ? openContextMenu(e, node) : undefined}
           ondragstart={node.kind === "folder" ? (e) => onFolderDragStart(e, node) : undefined}
           ondragend={node.kind === "folder" ? onFolderDragEnd : undefined}
           ondragover={(e) => onNodeDragOver(e, node.key)}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -118,6 +118,9 @@ export const api = {
   renameFolder: (folderId: string, name: string) =>
     invoke<void>("rename_folder", { folderId, name }),
 
+  renameFolderPath: (sourcePath: string, newPath: string) =>
+    invoke<void>("rename_folder_path", { sourcePath, newPath }),
+
   getCipher: (id: string) => invoke<CipherDetail>("get_cipher", { id }),
 
   createCipher: (input: EditorPayload) =>

--- a/src/lib/vault.svelte.ts
+++ b/src/lib/vault.svelte.ts
@@ -424,13 +424,23 @@ export class VaultController {
     }
   }
 
-  async deleteFolder(folderId: string) {
+  async deleteFolder(folderIds: string[]) {
     // Vaultwarden's web UI doesn't let users delete folders at all;
     // this command is the only path. Sync after the call so detached
     // ciphers (Bitwarden semantics: items move to "no folder" rather
     // than being deleted) and the dropped folder both surface.
+    //
+    // Multiple ids cover the cascade case: Bitwarden folders are flat
+    // with `/` in the name, so the sidebar synthesises parents like
+    // `work` from a real `work/projects`. Deleting the visual `work`
+    // group means deleting every real folder whose path falls under
+    // it; the caller collects the ids and we delete them serially so
+    // partial failures still surface a sensible vault state on the
+    // next sync.
     try {
-      await api.deleteFolder(folderId);
+      for (const id of folderIds) {
+        await api.deleteFolder(id);
+      }
       this.summary = await api.sync();
     } catch (e) {
       this.error = formatError(e);
@@ -442,6 +452,23 @@ export class VaultController {
     if (trimmed.length === 0) return;
     try {
       await api.renameFolder(folderId, trimmed);
+      this.summary = await api.sync();
+    } catch (e) {
+      this.error = formatError(e);
+    }
+  }
+
+  async renameFolderPath(sourcePath: string, newPath: string) {
+    // Path-based rename so the sidebar can rename a synthetic parent
+    // (`work` showing only because `work/projects` exists) the same
+    // way it renames a real folder. The Rust side reuses
+    // `plan_folder_renames`, so descendants get re-prefixed in the
+    // same batch.
+    const source = sourcePath.trim();
+    const next = newPath.trim();
+    if (source.length === 0 || next.length === 0 || source === next) return;
+    try {
+      await api.renameFolderPath(source, next);
       this.summary = await api.sync();
     } catch (e) {
       this.error = formatError(e);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -182,8 +182,8 @@
                 onMoveCipherToFolder={(id, fid) => vault.moveCipherToFolder(id, fid)}
                 onMoveCipherToCollection={(id, cid) => vault.moveCipherToCollection(id, cid)}
                 onMoveFolderPath={(s, t) => vault.performFolderMove(s, t)}
-                onDeleteFolder={(id) => vault.deleteFolder(id)}
-                onRenameFolder={(id, name) => vault.renameFolder(id, name)}
+                onDeleteFolder={(ids) => vault.deleteFolder(ids)}
+                onRenameFolder={(src, dst) => vault.renameFolderPath(src, dst)}
               />
 
               <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->

--- a/tests/e2e/specs/folder-rename-delete-path.spec.mjs
+++ b/tests/e2e/specs/folder-rename-delete-path.spec.mjs
@@ -36,9 +36,16 @@ const CASCADE_CHILD_A = `${CASCADE_PARENT}/a`;
 const CASCADE_CHILD_B = `${CASCADE_PARENT}/b/deep`;
 
 describe("Folder rename + delete (path-based, cascade)", () => {
-  it("rename_folder_path renames the parent and every descendant in one batch", async () => {
+  before(async () => {
+    // Single login per spec file: WDIO keeps the same browser session
+    // across `it` blocks in this describe, so calling
+    // loginAsSeededUser in each one would deadlock on the URL input
+    // (already submitted in the first it). Same pattern as
+    // ssh-passphrase-import.spec.mjs.
     await loginAsSeededUser();
+  });
 
+  it("rename_folder_path renames the parent and every descendant in one batch", async () => {
     const ids = await browser.execute(
       async (parent, child, grandchild) => {
         // @ts-expect-error — tauri injects this global
@@ -99,8 +106,6 @@ describe("Folder rename + delete (path-based, cascade)", () => {
     // (path container for the leaf), and right-clicking it should
     // succeed: the rename cascades through the leaf without ever
     // requiring a real parent row.
-    await loginAsSeededUser();
-
     const leafId = await browser.execute(async (name) => {
       // @ts-expect-error
       const { invoke } = window.__TAURI__.core;
@@ -144,8 +149,6 @@ describe("Folder rename + delete (path-based, cascade)", () => {
     // store to delete them in sequence. Here we play the same script
     // through IPC to verify the server ends up consistent — every
     // listed folder gone, every cipher under them detached.
-    await loginAsSeededUser();
-
     const setup = await browser.execute(
       async (parent, childA, childB) => {
         // @ts-expect-error

--- a/tests/e2e/specs/folder-rename-delete-path.spec.mjs
+++ b/tests/e2e/specs/folder-rename-delete-path.spec.mjs
@@ -1,0 +1,229 @@
+// Path-based folder rename + cascade delete — end-to-end through
+// `rename_folder_path` (new) and a sequence of `delete_folder`
+// invocations of the kind the sidebar issues when the user deletes a
+// visual group.
+//
+// Why both paths matter: Bitwarden has no real folder hierarchy. A
+// folder named `work/projects` and a folder named `work` are two
+// independent rows. The sidebar paints them as a tree by splitting on
+// `/`, which means `work` can show up as a *synthetic* parent —
+// nothing on the server, just a path container the UI made up. Until
+// recently right-click did nothing on those, and renaming a real
+// `work` would orphan its `work/...` children. Both regressions were
+// observable to users; both are silent at the server layer; both
+// belong here.
+//
+// IPC-driven for the same reason `folder-rename-delete.spec.mjs` is.
+// The right-click menu's job is just to compose paths and call IPC,
+// and synthetic HTML5 events under WebDriver are flaky enough to
+// drown the signal we care about.
+
+import { loginAsSeededUser } from "../helpers/auth.mjs";
+
+const RUN = `${Date.now().toString(36)}`;
+const PARENT = `e2e-rnpath-${RUN}`;
+const CHILD = `${PARENT}/child`;
+const GRANDCHILD = `${PARENT}/child/leaf`;
+const RENAMED_PARENT = `e2e-renamed-${RUN}`;
+const RENAMED_CHILD = `${RENAMED_PARENT}/child`;
+const RENAMED_GRANDCHILD = `${RENAMED_PARENT}/child/leaf`;
+
+const SYNTH_CHILD = `e2e-synth-${RUN}/only`;
+const SYNTH_RENAMED = `e2e-synth-renamed-${RUN}/only`;
+
+const CASCADE_PARENT = `e2e-cascdel-${RUN}`;
+const CASCADE_CHILD_A = `${CASCADE_PARENT}/a`;
+const CASCADE_CHILD_B = `${CASCADE_PARENT}/b/deep`;
+
+describe("Folder rename + delete (path-based, cascade)", () => {
+  it("rename_folder_path renames the parent and every descendant in one batch", async () => {
+    await loginAsSeededUser();
+
+    const ids = await browser.execute(
+      async (parent, child, grandchild) => {
+        // @ts-expect-error — tauri injects this global
+        const { invoke } = window.__TAURI__.core;
+        const parentId = await invoke("create_folder", { name: parent });
+        const childId = await invoke("create_folder", { name: child });
+        const grandchildId = await invoke("create_folder", { name: grandchild });
+        return { parentId, childId, grandchildId };
+      },
+      PARENT,
+      CHILD,
+      GRANDCHILD,
+    );
+    if (!ids.parentId || !ids.childId || !ids.grandchildId) {
+      throw new Error(`create_folder did not return ids: ${JSON.stringify(ids)}`);
+    }
+
+    await browser.execute(
+      async (sourcePath, newPath) => {
+        // @ts-expect-error
+        const { invoke } = window.__TAURI__.core;
+        await invoke("rename_folder_path", { sourcePath, newPath });
+      },
+      PARENT,
+      RENAMED_PARENT,
+    );
+
+    // Sync forces a server round-trip so a regression that only
+    // mutated the local cache (without PUTting) would surface here.
+    const folders = await browser.execute(async () => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      const summary = await invoke("sync");
+      return summary.folders.map((f) => ({ id: f.id, name: f.name }));
+    });
+    const lookup = new Map(folders.map((f) => [f.id, f.name]));
+
+    if (lookup.get(ids.parentId) !== RENAMED_PARENT) {
+      throw new Error(
+        `expected parent renamed to ${JSON.stringify(RENAMED_PARENT)}, got ${JSON.stringify(lookup.get(ids.parentId))}`,
+      );
+    }
+    if (lookup.get(ids.childId) !== RENAMED_CHILD) {
+      throw new Error(
+        `expected child cascade-renamed to ${JSON.stringify(RENAMED_CHILD)}, got ${JSON.stringify(lookup.get(ids.childId))}`,
+      );
+    }
+    if (lookup.get(ids.grandchildId) !== RENAMED_GRANDCHILD) {
+      throw new Error(
+        `expected grandchild cascade-renamed to ${JSON.stringify(RENAMED_GRANDCHILD)}, got ${JSON.stringify(lookup.get(ids.grandchildId))}`,
+      );
+    }
+  });
+
+  it("rename_folder_path on a synthetic parent rewrites every descendant even when the parent has no row", async () => {
+    // Only the leaf exists on the server — there is no `e2e-synth-${RUN}`
+    // row. The sidebar still paints `e2e-synth-${RUN}` as a folder
+    // (path container for the leaf), and right-clicking it should
+    // succeed: the rename cascades through the leaf without ever
+    // requiring a real parent row.
+    await loginAsSeededUser();
+
+    const leafId = await browser.execute(async (name) => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      return await invoke("create_folder", { name });
+    }, SYNTH_CHILD);
+    if (typeof leafId !== "string" || leafId.length === 0) {
+      throw new Error(`create_folder did not return an id: ${JSON.stringify(leafId)}`);
+    }
+
+    const synthParent = SYNTH_CHILD.split("/")[0];
+    const synthRenamedParent = SYNTH_RENAMED.split("/")[0];
+    await browser.execute(
+      async (sourcePath, newPath) => {
+        // @ts-expect-error
+        const { invoke } = window.__TAURI__.core;
+        await invoke("rename_folder_path", { sourcePath, newPath });
+      },
+      synthParent,
+      synthRenamedParent,
+    );
+
+    const found = await browser.execute(async (id) => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      const summary = await invoke("sync");
+      return summary.folders.find((f) => f.id === id) ?? null;
+    }, leafId);
+
+    if (!found) throw new Error(`leaf ${leafId} disappeared after synth-parent rename`);
+    if (found.name !== SYNTH_RENAMED) {
+      throw new Error(
+        `expected leaf cascaded to ${JSON.stringify(SYNTH_RENAMED)}, got ${JSON.stringify(found.name)}`,
+      );
+    }
+  });
+
+  it("cascade delete drops every folder id the sidebar collected and detaches their ciphers", async () => {
+    // Mirrors what `VaultSidebar.svelte`'s confirmDelete does: the
+    // sidebar walks the subtree under the right-clicked node, collects
+    // every real folder id (`collectFolderIds`), and then asks the
+    // store to delete them in sequence. Here we play the same script
+    // through IPC to verify the server ends up consistent — every
+    // listed folder gone, every cipher under them detached.
+    await loginAsSeededUser();
+
+    const setup = await browser.execute(
+      async (parent, childA, childB) => {
+        // @ts-expect-error
+        const { invoke } = window.__TAURI__.core;
+        const parentId = await invoke("create_folder", { name: parent });
+        const childAId = await invoke("create_folder", { name: childA });
+        const childBId = await invoke("create_folder", { name: childB });
+        const cipherInParent = await invoke("create_cipher", {
+          input: {
+            cipherType: 1,
+            name: `e2e-cascdel-cipher-parent-${parent}`,
+            folderId: parentId,
+            favorite: false,
+            notes: null,
+            organizationId: null,
+            collectionIds: [],
+            login: { username: "u", password: "p", uris: [], totp: null },
+          },
+        });
+        const cipherInChild = await invoke("create_cipher", {
+          input: {
+            cipherType: 1,
+            name: `e2e-cascdel-cipher-child-${parent}`,
+            folderId: childAId,
+            favorite: false,
+            notes: null,
+            organizationId: null,
+            collectionIds: [],
+            login: { username: "u", password: "p", uris: [], totp: null },
+          },
+        });
+        return { parentId, childAId, childBId, cipherInParent, cipherInChild };
+      },
+      CASCADE_PARENT,
+      CASCADE_CHILD_A,
+      CASCADE_CHILD_B,
+    );
+
+    // Delete every collected id in sequence, the way the store does.
+    // Order shouldn't matter — assert that explicitly by deleting the
+    // parent last.
+    await browser.execute(
+      async (ids) => {
+        // @ts-expect-error
+        const { invoke } = window.__TAURI__.core;
+        for (const id of ids) {
+          await invoke("delete_folder", { folderId: id });
+        }
+      },
+      [setup.childAId, setup.childBId, setup.parentId],
+    );
+
+    const after = await browser.execute(async () => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      const summary = await invoke("sync");
+      return { folders: summary.folders, ciphers: summary.ciphers };
+    });
+
+    const folderIds = new Set(after.folders.map((f) => f.id));
+    for (const id of [setup.parentId, setup.childAId, setup.childBId]) {
+      if (folderIds.has(id)) {
+        throw new Error(`folder ${id} still present after cascade delete`);
+      }
+    }
+
+    for (const cipherId of [setup.cipherInParent, setup.cipherInChild]) {
+      const survivor = after.ciphers.find((c) => c.id === cipherId);
+      if (!survivor) {
+        throw new Error(
+          `cipher ${cipherId} was deleted alongside its folder — Bitwarden semantics is detach, not cascade`,
+        );
+      }
+      if (survivor.folderId !== null) {
+        throw new Error(
+          `cipher ${cipherId} should be detached after its folder was deleted; got ${JSON.stringify(survivor.folderId)}`,
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Right-click on any folder node now opens the menu, including synthetic parents (`work` showing only because `work/projects` exists). Both rename and delete cascade through every folder whose path equals or sits under the clicked node — the user no longer has to care whether a node is real or synthesised.
- New `rename_folder_path` Tauri command reuses the same `plan_folder_renames` machinery as `move_folder_path`, so the rename batch is atomic on the Rust side. Cascade delete is driven from the store by collecting descendant ids and looping through `delete_folder` (Bitwarden detaches ciphers rather than cascade-deleting, which is the wanted behaviour).
- Confirmation dialog now reports the sub-folder count when more than one folder is going to be deleted.

## Test plan
- [ ] CI: `frontend` (svelte-check + vitest), `rust` (fmt/clippy/audit/test), `e2e`, `smoke-release`
- [ ] New `tests/e2e/specs/folder-rename-delete-path.spec.mjs` covers:
  - cascade rename of a real parent with two levels of descendants
  - cascade rename of a synthetic parent (no row on the server, only a leaf `parent/leaf`)
  - cascade delete of a parent + multiple descendants, asserting all rows gone and ciphers detached
- [ ] Manual smoke once the AppImage from `dev-build` is downloaded: right-click a synthetic parent → delete; right-click a synthetic parent → rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)