### PR TITLE
chore(deps): ignore semver-major bumps blocked by rsa 0.9

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,30 @@ updates:
       - rust
     commit-message:
       prefix: "chore(deps-rust)"
+    # Ignore semver-major bumps for crates that depend on the same
+    # `digest 0.10` / `rand_core 0.6` slice as `rsa 0.9` (our stable).
+    # Bumping any one of them breaks the other six because `rsa` still
+    # carries the old traits. Lift these entries the moment `rsa 0.10`
+    # ships stable on crates.io — Dependabot will then re-open all the
+    # major bumps as one coherent group via the `rust-crypto` group
+    # below. Past blocked attempts: PR #31 (group bump), PR #35 (rand).
+    ignore:
+      - dependency-name: rand
+        update-types: ["version-update:semver-major"]
+      - dependency-name: sha2
+        update-types: ["version-update:semver-major"]
+      - dependency-name: sha1
+        update-types: ["version-update:semver-major"]
+      - dependency-name: hmac
+        update-types: ["version-update:semver-major"]
+      - dependency-name: hkdf
+        update-types: ["version-update:semver-major"]
+      - dependency-name: pbkdf2
+        update-types: ["version-update:semver-major"]
+      - dependency-name: aes
+        update-types: ["version-update:semver-major"]
+      - dependency-name: cbc
+        update-types: ["version-update:semver-major"]
     groups:
       rust-crypto:
         patterns:


### PR DESCRIPTION
## Summary
- \`rsa\` stable is still 0.9.x (0.10 is RC), pinning us to \`rand_core 0.6\` and \`digest 0.10\`. Any major bump of \`rand\`, \`sha2\`, \`sha1\`, \`hmac\`, \`hkdf\`, \`pbkdf2\`, \`aes\`, or \`cbc\` breaks the link against \`rsa\`. PRs #31 and #35 just cycled red on this.
- Adds eight \`ignore\` entries scoped to \`version-update:semver-major\` only — patches and minors still flow.
- Comment in the YAML names the unblock condition: drop these the moment \`rsa 0.10\` ships stable, Dependabot will then re-open the bumps as a coherent group via the existing \`rust-crypto\` group.

## Test plan
- [ ] CI passes (only frontend/Rust/E2E jobs run; this only changes \`.github/dependabot.yml\`)
- [ ] Manual: next Monday Dependabot run no longer reopens the same blocked PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)