### PR TITLE
chore(deps): group wdio packages and ignore semver-major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,15 @@ updates:
       - javascript
     commit-message:
       prefix: "chore(deps-npm)"
+    # Ignore semver-major bumps for `@wdio/*`: the runtime plugin
+    # loader rejects mismatched majors across the cli / local-runner /
+    # mocha-framework / spec-reporter set, so a single-package major
+    # always lands E2E red. Past blocked attempt: PR #43 (mocha-framework
+    # 7→9 alone). When we choose to upgrade the whole family, lift this
+    # entry and let the `wdio` group below batch the bump.
+    ignore:
+      - dependency-name: "@wdio/*"
+        update-types: ["version-update:semver-major"]
     groups:
       svelte:
         patterns:
@@ -86,6 +95,10 @@ updates:
       paraglide:
         patterns:
           - "@inlang/*"
+      wdio:
+        patterns:
+          - "@wdio/*"
+          - webdriverio
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Summary
- \`@wdio/cli\` / \`@wdio/local-runner\` / \`@wdio/mocha-framework\` / \`@wdio/spec-reporter\` enforce matching majors at the plugin loader. PR #43 just cycled red on a single-package \`mocha-framework\` 7→9 because the v7 cli couldn't load the v9 framework.
- Adds a \`wdio\` group so the next coordinated bump lands as one PR, plus a semver-major ignore so isolated majors stop being filed. Same pattern as the rust-crypto block earlier today.

## Test plan
- [ ] CI passes (only \`.github/dependabot.yml\` changes)
- [ ] Next Monday Dependabot run no longer files \`@wdio/*\` major bumps in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)