### PR TITLE
feat(tray): system-tray icon + close-to-tray (closes #38)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -75,6 +75,15 @@ updates:
       - javascript
     commit-message:
       prefix: "chore(deps-npm)"
+    # Ignore semver-major bumps for `@wdio/*`: the runtime plugin
+    # loader rejects mismatched majors across the cli / local-runner /
+    # mocha-framework / spec-reporter set, so a single-package major
+    # always lands E2E red. Past blocked attempt: PR #43 (mocha-framework
+    # 7→9 alone). When we choose to upgrade the whole family, lift this
+    # entry and let the `wdio` group below batch the bump.
+    ignore:
+      - dependency-name: "@wdio/*"
+        update-types: ["version-update:semver-major"]
     groups:
       svelte:
         patterns:
@@ -86,6 +95,10 @@ updates:
       paraglide:
         patterns:
           - "@inlang/*"
+      wdio:
+        patterns:
+          - "@wdio/*"
+          - webdriverio
 
   - package-ecosystem: github-actions
     directory: /

--- a/messages/en.json
+++ b/messages/en.json
@@ -281,6 +281,10 @@
   "stats_auto_lock_minutes": "{count} min",
   "stats_auto_lock_hour": "1 h",
 
+  "settings_close_to_tray": "Close button",
+  "settings_close_to_tray_tray": "Hide to tray",
+  "settings_close_to_tray_quit": "Quit Clavix",
+
   "clipboard_toast": "Clipboard ({label}) will be cleared in {seconds}s",
 
   "type_login": "Login",

--- a/messages/en.json
+++ b/messages/en.json
@@ -284,6 +284,9 @@
   "settings_close_to_tray": "Close button",
   "settings_close_to_tray_tray": "Hide to tray",
   "settings_close_to_tray_quit": "Quit Clavix",
+  "settings_minimize_to_tray": "Minimise button",
+  "settings_minimize_to_tray_tray": "Hide to tray",
+  "settings_minimize_to_tray_taskbar": "Minimise to taskbar",
 
   "clipboard_toast": "Clipboard ({label}) will be cleared in {seconds}s",
 

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -281,6 +281,10 @@
   "stats_auto_lock_minutes": "{count} min",
   "stats_auto_lock_hour": "1 h",
 
+  "settings_close_to_tray": "Bouton Fermer",
+  "settings_close_to_tray_tray": "Réduire dans la zone de notification",
+  "settings_close_to_tray_quit": "Quitter Clavix",
+
   "clipboard_toast": "Presse-papier ({label}) effacé dans {seconds}s",
 
   "type_login": "Login",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -284,6 +284,9 @@
   "settings_close_to_tray": "Bouton Fermer",
   "settings_close_to_tray_tray": "Réduire dans la zone de notification",
   "settings_close_to_tray_quit": "Quitter Clavix",
+  "settings_minimize_to_tray": "Bouton Réduire",
+  "settings_minimize_to_tray_tray": "Réduire dans la zone de notification",
+  "settings_minimize_to_tray_taskbar": "Réduire dans la barre des tâches",
 
   "clipboard_toast": "Presse-papier ({label}) effacé dans {seconds}s",
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod auth;
 pub mod cipher;
 pub mod move_share;
 pub mod ssh;
+pub mod tray;
 pub mod vault;

--- a/src-tauri/src/commands/tray.rs
+++ b/src-tauri/src/commands/tray.rs
@@ -41,6 +41,18 @@ pub fn set_close_to_tray(state: State<'_, AppState>, value: bool) -> Result<()> 
     Ok(())
 }
 
+/// Sibling of `set_close_to_tray` for the `_` minimise button.
+/// Decides whether minimising hides into the tray (true, default)
+/// or sends the window to the taskbar (false). Same hydration
+/// pattern from the renderer.
+#[tauri::command]
+pub fn set_minimize_to_tray(state: State<'_, AppState>, value: bool) -> Result<()> {
+    state
+        .minimize_to_tray
+        .store(value, std::sync::atomic::Ordering::Relaxed);
+    Ok(())
+}
+
 /// Wire the tray icon onto an `AppHandle`. Failure is non-fatal: a
 /// CI runner or a Linux desktop without a system tray (xvfb, plain
 /// Sway without `waybar` etc.) just gets a working app without the
@@ -136,24 +148,60 @@ fn lock_session(app: &AppHandle) {
     crate::services::auth::clear_pending_two_factor(&state);
 }
 
-/// Wire `WindowEvent::CloseRequested` to the renderer-mirrored
-/// `close_to_tray` flag: if it's true (default), hide the window
-/// into the tray and call `prevent_close` so Tauri doesn't tear the
-/// app down. If false, this is a no-op and the default close path
-/// runs as usual.
+/// Two-branch window-event hook:
+///
+///   - `CloseRequested` → if `close_to_tray` is set, hide the
+///     window and call `prevent_close()` so Tauri leaves the
+///     process up.
+///   - `Resized` → on a minimise transition (`is_minimized()` true
+///     after the resize), if `minimize_to_tray` is set, unminimise
+///     + hide so the window lives in the tray rather than the
+///     taskbar.
+///
+/// Both branches no-op when the corresponding preference is off.
+/// Native cross-platform minimise detection has no dedicated
+/// Tauri/tao event variant — `Resized` fires on every minimise
+/// path on Windows and most Linux WMs, and `is_minimized()` then
+/// confirms the transition. macOS minimise (cmd-M to dock) is best
+/// effort: the Resized signal there isn't reliable, so the
+/// preference may not always intercept on macOS until the upstream
+/// API exposes a proper minimise event. Documented for the user.
 pub fn handle_window_event(app: &AppHandle, event: &WindowEvent) {
-    let WindowEvent::CloseRequested { api, .. } = event else {
-        return;
-    };
-    let state = app.state::<AppState>();
-    if !state
-        .close_to_tray
-        .load(std::sync::atomic::Ordering::Relaxed)
-    {
-        return;
+    match event {
+        WindowEvent::CloseRequested { api, .. } => {
+            let state = app.state::<AppState>();
+            if !state
+                .close_to_tray
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                return;
+            }
+            if let Some(window) = app.get_webview_window(MAIN_WINDOW) {
+                let _ = window.hide();
+            }
+            api.prevent_close();
+        }
+        WindowEvent::Resized(_) => {
+            let state = app.state::<AppState>();
+            if !state
+                .minimize_to_tray
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                return;
+            }
+            if let Some(window) = app.get_webview_window(MAIN_WINDOW) {
+                if matches!(window.is_minimized(), Ok(true)) {
+                    // Unminimise first so `hide()` doesn't have to
+                    // race the OS minimise animation. Cheap on
+                    // Windows; a brief flicker on Linux WMs that
+                    // animate minimise is acceptable for the
+                    // intended UX (the window disappears into the
+                    // tray, not the taskbar).
+                    let _ = window.unminimize();
+                    let _ = window.hide();
+                }
+            }
+        }
+        _ => {}
     }
-    if let Some(window) = app.get_webview_window(MAIN_WINDOW) {
-        let _ = window.hide();
-    }
-    api.prevent_close();
 }

--- a/src-tauri/src/commands/tray.rs
+++ b/src-tauri/src/commands/tray.rs
@@ -148,17 +148,13 @@ fn lock_session(app: &AppHandle) {
     crate::services::auth::clear_pending_two_factor(&state);
 }
 
-/// Two-branch window-event hook:
-///
-///   - `CloseRequested` → if `close_to_tray` is set, hide the
-///     window and call `prevent_close()` so Tauri leaves the
-///     process up.
-///   - `Resized` → on a minimise transition (`is_minimized()` true
-///     after the resize), if `minimize_to_tray` is set, unminimise
-///     + hide so the window lives in the tray rather than the
-///     taskbar.
-///
-/// Both branches no-op when the corresponding preference is off.
+/// Two-branch window-event hook. On `CloseRequested`: if
+/// `close_to_tray` is set, hide the window and call
+/// `prevent_close()` so Tauri leaves the process up. On `Resized`:
+/// on a minimise transition (`is_minimized()` true after the
+/// resize), if `minimize_to_tray` is set, unminimise + hide so the
+/// window lives in the tray rather than the taskbar. Both branches
+/// no-op when the corresponding preference is off.
 /// Native cross-platform minimise detection has no dedicated
 /// Tauri/tao event variant — `Resized` fires on every minimise
 /// path on Windows and most Linux WMs, and `is_minimized()` then

--- a/src-tauri/src/commands/tray.rs
+++ b/src-tauri/src/commands/tray.rs
@@ -1,0 +1,159 @@
+//! System-tray wiring (issue #38).
+//!
+//! Three responsibilities:
+//!   - `build_tray` constructs the tray icon, its right-click menu
+//!     ("Ouvrir" / "Verrouiller maintenant" / "Quitter") and the
+//!     left-click toggle. Called once from `lib.rs::run` setup.
+//!   - `handle_window_close` interprets `WindowEvent::CloseRequested`
+//!     against the user's `close_to_tray` preference: hide-or-quit.
+//!   - `set_close_to_tray` is the IPC the renderer calls every time
+//!     the preference changes (and on bootstrap, to hydrate the
+//!     Rust mirror from `localStorage`).
+//!
+//! Native menu strings are hard-coded in French. The renderer-side
+//! Paraglide pipeline doesn't reach native menus; supporting English
+//! tray entries would mean reading the user's locale from a config
+//! file at startup and rebuilding the tray on language change. Out
+//! of scope until someone asks.
+
+use tauri::menu::{Menu, MenuItem};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri::{AppHandle, Manager, State, WindowEvent};
+
+use crate::error::Result;
+use crate::state::AppState;
+
+const TRAY_ID: &str = "clavix-tray";
+const ITEM_OPEN: &str = "tray.open";
+const ITEM_LOCK: &str = "tray.lock";
+const ITEM_QUIT: &str = "tray.quit";
+const MAIN_WINDOW: &str = "clavix";
+
+/// Renderer-driven flag that decides what the X button does.
+/// Mirrors `prefs.closeToTray` in `src/lib/prefs.svelte.ts`. The
+/// renderer calls this on bootstrap (to hydrate the Rust mirror)
+/// and again every time the user toggles the preference.
+#[tauri::command]
+pub fn set_close_to_tray(state: State<'_, AppState>, value: bool) -> Result<()> {
+    state
+        .close_to_tray
+        .store(value, std::sync::atomic::Ordering::Relaxed);
+    Ok(())
+}
+
+/// Wire the tray icon onto an `AppHandle`. Failure is non-fatal: a
+/// CI runner or a Linux desktop without a system tray (xvfb, plain
+/// Sway without `waybar` etc.) just gets a working app without the
+/// tray entry. Logs the reason so it's traceable in the dev console.
+pub fn build_tray(app: &AppHandle) {
+    let icon = match app.default_window_icon().cloned() {
+        Some(icon) => icon,
+        None => {
+            eprintln!("[clavix] tray icon setup skipped: no default window icon");
+            return;
+        }
+    };
+
+    let result = (|| -> tauri::Result<()> {
+        let open = MenuItem::with_id(app, ITEM_OPEN, "Ouvrir Clavix", true, None::<&str>)?;
+        let lock = MenuItem::with_id(app, ITEM_LOCK, "Verrouiller maintenant", true, None::<&str>)?;
+        let quit = MenuItem::with_id(app, ITEM_QUIT, "Quitter", true, None::<&str>)?;
+        let menu = Menu::with_items(app, &[&open, &lock, &quit])?;
+
+        TrayIconBuilder::with_id(TRAY_ID)
+            .icon(icon)
+            .tooltip("Clavix")
+            .menu(&menu)
+            .on_menu_event(|app, event| match event.id.as_ref() {
+                ITEM_OPEN => show_main_window(app),
+                ITEM_LOCK => lock_session(app),
+                ITEM_QUIT => app.exit(0),
+                _ => {}
+            })
+            .on_tray_icon_event(|tray, event| {
+                // Left-click toggles. Right-click opens the menu
+                // (handled by the menu wiring above) so we ignore it
+                // here. Match on `Up` so the toggle fires once per
+                // click rather than twice (Down + Up).
+                if let TrayIconEvent::Click {
+                    button: MouseButton::Left,
+                    button_state: MouseButtonState::Up,
+                    ..
+                } = event
+                {
+                    toggle_main_window(tray.app_handle());
+                }
+            })
+            .build(app)?;
+        Ok(())
+    })();
+
+    if let Err(e) = result {
+        eprintln!("[clavix] tray icon setup failed (non-fatal): {e}");
+    }
+}
+
+fn show_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW) {
+        let _ = window.show();
+        let _ = window.unminimize();
+        let _ = window.set_focus();
+    }
+}
+
+fn toggle_main_window(app: &AppHandle) {
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW) {
+        match window.is_visible() {
+            Ok(true) => {
+                let _ = window.hide();
+            }
+            Ok(false) | Err(_) => {
+                let _ = window.show();
+                let _ = window.unminimize();
+                let _ = window.set_focus();
+            }
+        }
+    }
+}
+
+fn lock_session(app: &AppHandle) {
+    let state = app.state::<AppState>();
+    // Same teardown as `commands::auth::lock`. Inlined rather than
+    // calling the Tauri command directly because we hold an
+    // `AppHandle`, not the `State<'_, AppState>` shape Tauri's
+    // dispatcher would hand us — and we don't need a return value.
+    let agent = {
+        let mut slot = state.ssh_agent.lock();
+        slot.take()
+    };
+    if let Some(handle) = agent {
+        handle.stop_sync();
+    }
+    {
+        let mut guard = state.session.lock();
+        *guard = None;
+    }
+    crate::services::auth::clear_pending_two_factor(&state);
+}
+
+/// Wire `WindowEvent::CloseRequested` to the renderer-mirrored
+/// `close_to_tray` flag: if it's true (default), hide the window
+/// into the tray and call `prevent_close` so Tauri doesn't tear the
+/// app down. If false, this is a no-op and the default close path
+/// runs as usual.
+pub fn handle_window_event(app: &AppHandle, event: &WindowEvent) {
+    let WindowEvent::CloseRequested { api, .. } = event else {
+        return;
+    };
+    let state = app.state::<AppState>();
+    if !state
+        .close_to_tray
+        .load(std::sync::atomic::Ordering::Relaxed)
+    {
+        return;
+    }
+    if let Some(window) = app.get_webview_window(MAIN_WINDOW) {
+        let _ = window.hide();
+    }
+    api.prevent_close();
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -38,7 +38,21 @@ pub fn run() {
         .manage(AppState::default())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .on_window_event(|window, event| {
+            // Close-to-tray hook. The handler is a no-op when the
+            // user disables the preference; otherwise it hides the
+            // window and calls `prevent_close()` so Tauri leaves the
+            // process up. See `commands::tray` for the full story.
+            commands::tray::handle_window_event(window.app_handle(), event);
+        })
         .setup(|app| {
+            // Tray icon + right-click menu (Ouvrir / Verrouiller /
+            // Quitter). Non-fatal if it fails — environments without
+            // a system tray (CI under xvfb, some minimal WMs) just
+            // run without the tray entry, which is the same shape
+            // the app had pre-#38.
+            commands::tray::build_tray(app.handle());
+
             // Auto-lock watchdog. Backend safety net: if the WebView freezes
             // or the JS timer is disabled, the session must still drop after
             // the configured idle window. Polls every 30 s — slow enough to be
@@ -111,6 +125,7 @@ pub fn run() {
             commands::ssh::decrypt_ssh_private_key,
             commands::ssh::generate_ssh_key,
             commands::ssh::ssh_auth_sock,
+            commands::tray::set_close_to_tray,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -126,6 +126,7 @@ pub fn run() {
             commands::ssh::generate_ssh_key,
             commands::ssh::ssh_auth_sock,
             commands::tray::set_close_to_tray,
+            commands::tray::set_minimize_to_tray,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
 use std::time::Instant;
 
 use parking_lot::Mutex;
@@ -32,6 +33,15 @@ pub struct AppState {
     /// two IPC calls. Cleared on success, on auth failure, on
     /// `cancel_two_factor`, and after the TTL elapses.
     pub pending_2fa: Mutex<Option<PendingTwoFactor>>,
+    /// Mirrors the renderer's `prefs.closeToTray`. Read by the
+    /// `WindowEvent::CloseRequested` handler in `lib.rs::run` to
+    /// decide whether the X button hides the window into the tray
+    /// (true, default) or quits the process (false). An atomic so
+    /// the window-event handler can read it without taking a mutex
+    /// — close events fire on the main loop and any contention here
+    /// would block UI input. Updated through
+    /// `commands::tray::set_close_to_tray`.
+    pub close_to_tray: AtomicBool,
 }
 
 impl Default for AppState {
@@ -42,6 +52,11 @@ impl Default for AppState {
             last_activity: Mutex::new(Instant::now()),
             auto_lock_minutes: Mutex::new(None),
             pending_2fa: Mutex::new(None),
+            // Default to true so users on a fresh install land on the
+            // common password-manager behaviour (KeePassXC, Bitwarden
+            // Desktop): X button hides into the tray. The renderer
+            // overwrites this from localStorage on bootstrap.
+            close_to_tray: AtomicBool::new(true),
         }
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -42,6 +42,12 @@ pub struct AppState {
     /// would block UI input. Updated through
     /// `commands::tray::set_close_to_tray`.
     pub close_to_tray: AtomicBool,
+    /// Same shape as `close_to_tray` but for the `_` minimise
+    /// button: when true (default), a minimise transition is
+    /// converted to a hide-into-tray. When false, the window goes
+    /// to the taskbar like any other app. Read by the
+    /// `WindowEvent::Resized` handler.
+    pub minimize_to_tray: AtomicBool,
 }
 
 impl Default for AppState {
@@ -57,6 +63,7 @@ impl Default for AppState {
             // Desktop): X button hides into the tray. The renderer
             // overwrites this from localStorage on bootstrap.
             close_to_tray: AtomicBool::new(true),
+            minimize_to_tray: AtomicBool::new(true),
         }
     }
 }

--- a/src/lib/StatsDialog.svelte
+++ b/src/lib/StatsDialog.svelte
@@ -10,10 +10,12 @@
     themePref: ThemePref;
     autoLockMinutes: number;
     closeToTray: boolean;
+    minimizeToTray: boolean;
     onApplyLocale: (loc: Locale) => void;
     onApplyTheme: (pref: ThemePref) => void;
     onApplyAutoLock: (minutes: number) => void;
     onApplyCloseToTray: (value: boolean) => void;
+    onApplyMinimizeToTray: (value: boolean) => void;
     onCopySocketPath: (socketPath: string) => void;
   };
 
@@ -23,10 +25,12 @@
     themePref,
     autoLockMinutes,
     closeToTray,
+    minimizeToTray,
     onApplyLocale,
     onApplyTheme,
     onApplyAutoLock,
     onApplyCloseToTray,
+    onApplyMinimizeToTray,
     onCopySocketPath,
   }: Props = $props();
 
@@ -216,6 +220,19 @@
         >
           <option value="tray">{m.settings_close_to_tray_tray()}</option>
           <option value="quit">{m.settings_close_to_tray_quit()}</option>
+        </select>
+      </dd>
+      <dt>{m.settings_minimize_to_tray()}</dt>
+      <dd>
+        <select
+          value={minimizeToTray ? "tray" : "taskbar"}
+          onchange={(e) =>
+            onApplyMinimizeToTray(
+              (e.currentTarget as HTMLSelectElement).value === "tray",
+            )}
+        >
+          <option value="tray">{m.settings_minimize_to_tray_tray()}</option>
+          <option value="taskbar">{m.settings_minimize_to_tray_taskbar()}</option>
         </select>
       </dd>
     </dl>

--- a/src/lib/StatsDialog.svelte
+++ b/src/lib/StatsDialog.svelte
@@ -9,9 +9,11 @@
     currentLocale: Locale;
     themePref: ThemePref;
     autoLockMinutes: number;
+    closeToTray: boolean;
     onApplyLocale: (loc: Locale) => void;
     onApplyTheme: (pref: ThemePref) => void;
     onApplyAutoLock: (minutes: number) => void;
+    onApplyCloseToTray: (value: boolean) => void;
     onCopySocketPath: (socketPath: string) => void;
   };
 
@@ -20,9 +22,11 @@
     currentLocale,
     themePref,
     autoLockMinutes,
+    closeToTray,
     onApplyLocale,
     onApplyTheme,
     onApplyAutoLock,
+    onApplyCloseToTray,
     onCopySocketPath,
   }: Props = $props();
 
@@ -199,6 +203,19 @@
           <option value={15}>{m.stats_auto_lock_minutes({ count: "15" })}</option>
           <option value={30}>{m.stats_auto_lock_minutes({ count: "30" })}</option>
           <option value={60}>{m.stats_auto_lock_hour()}</option>
+        </select>
+      </dd>
+      <dt>{m.settings_close_to_tray()}</dt>
+      <dd>
+        <select
+          value={closeToTray ? "tray" : "quit"}
+          onchange={(e) =>
+            onApplyCloseToTray(
+              (e.currentTarget as HTMLSelectElement).value === "tray",
+            )}
+        >
+          <option value="tray">{m.settings_close_to_tray_tray()}</option>
+          <option value="quit">{m.settings_close_to_tray_quit()}</option>
         </select>
       </dd>
     </dl>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -95,6 +95,9 @@ export const api = {
 
   setCloseToTray: (value: boolean) => invoke<void>("set_close_to_tray", { value }),
 
+  setMinimizeToTray: (value: boolean) =>
+    invoke<void>("set_minimize_to_tray", { value }),
+
   webauthnSignChallenge: (challengeJson: string) =>
     invoke<string>("webauthn_sign_challenge", { challengeJson }),
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -93,6 +93,8 @@ export const api = {
 
   setAutoLockMinutes: (minutes: number) => invoke<void>("set_auto_lock_minutes", { minutes }),
 
+  setCloseToTray: (value: boolean) => invoke<void>("set_close_to_tray", { value }),
+
   webauthnSignChallenge: (challengeJson: string) =>
     invoke<string>("webauthn_sign_challenge", { challengeJson }),
 

--- a/src/lib/prefs.svelte.ts
+++ b/src/lib/prefs.svelte.ts
@@ -6,6 +6,7 @@ const THEME_STORAGE_KEY = "clavix.theme";
 const TREE_WIDTH_STORAGE_KEY = "clavix.treeWidth";
 const DETAIL_HEIGHT_STORAGE_KEY = "clavix.detailHeight";
 const AUTO_LOCK_STORAGE_KEY = "clavix.autoLockMinutes";
+const CLOSE_TO_TRAY_STORAGE_KEY = "clavix.closeToTray";
 const ONBOARDED_STORAGE_KEY = "clavix.onboarded";
 const VISIBLE_COLUMNS_STORAGE_KEY = "clavix.visibleColumns";
 
@@ -28,6 +29,10 @@ export const DETAIL_HEIGHT_MIN = 160;
 export const DETAIL_HEIGHT_MAX = 900;
 const DETAIL_HEIGHT_DEFAULT = 320;
 const AUTO_LOCK_DEFAULT_MINUTES = 10;
+// Default matches the Rust mirror: X button hides into tray. Same
+// shape as KeePassXC and Bitwarden Desktop. Users that want the X
+// to quit flip this off in Préférences.
+const CLOSE_TO_TRAY_DEFAULT = true;
 
 export class PrefsController {
   currentLocale = $state<Locale>("fr");
@@ -35,6 +40,7 @@ export class PrefsController {
   treeWidth = $state<number>(TREE_WIDTH_DEFAULT);
   detailHeight = $state<number>(DETAIL_HEIGHT_DEFAULT);
   autoLockMinutes = $state<number>(AUTO_LOCK_DEFAULT_MINUTES);
+  closeToTray = $state<boolean>(CLOSE_TO_TRAY_DEFAULT);
   lastActivityAt = $state<number>(Date.now());
   visibleColumns = $state<CipherListColumns>({ ...VISIBLE_COLUMNS_DEFAULT });
 
@@ -80,6 +86,13 @@ export class PrefsController {
         if (Number.isFinite(parsed) && parsed >= 0) {
           this.autoLockMinutes = parsed;
         }
+      }
+      const savedTray = localStorage.getItem(CLOSE_TO_TRAY_STORAGE_KEY);
+      // Only flip the default when localStorage explicitly says
+      // "false" — anything else (including missing key for fresh
+      // installs) keeps the hide-to-tray behaviour.
+      if (savedTray === "false") {
+        this.closeToTray = false;
       }
       const savedColumns = localStorage.getItem(VISIBLE_COLUMNS_STORAGE_KEY);
       if (savedColumns) {
@@ -166,6 +179,15 @@ export class PrefsController {
     this.autoLockMinutes = minutes;
     try {
       localStorage.setItem(AUTO_LOCK_STORAGE_KEY, String(minutes));
+    } catch {
+      // ignore
+    }
+  }
+
+  setCloseToTray(value: boolean) {
+    this.closeToTray = value;
+    try {
+      localStorage.setItem(CLOSE_TO_TRAY_STORAGE_KEY, String(value));
     } catch {
       // ignore
     }

--- a/src/lib/prefs.svelte.ts
+++ b/src/lib/prefs.svelte.ts
@@ -7,6 +7,7 @@ const TREE_WIDTH_STORAGE_KEY = "clavix.treeWidth";
 const DETAIL_HEIGHT_STORAGE_KEY = "clavix.detailHeight";
 const AUTO_LOCK_STORAGE_KEY = "clavix.autoLockMinutes";
 const CLOSE_TO_TRAY_STORAGE_KEY = "clavix.closeToTray";
+const MINIMIZE_TO_TRAY_STORAGE_KEY = "clavix.minimizeToTray";
 const ONBOARDED_STORAGE_KEY = "clavix.onboarded";
 const VISIBLE_COLUMNS_STORAGE_KEY = "clavix.visibleColumns";
 
@@ -33,6 +34,7 @@ const AUTO_LOCK_DEFAULT_MINUTES = 10;
 // shape as KeePassXC and Bitwarden Desktop. Users that want the X
 // to quit flip this off in Préférences.
 const CLOSE_TO_TRAY_DEFAULT = true;
+const MINIMIZE_TO_TRAY_DEFAULT = true;
 
 export class PrefsController {
   currentLocale = $state<Locale>("fr");
@@ -41,6 +43,7 @@ export class PrefsController {
   detailHeight = $state<number>(DETAIL_HEIGHT_DEFAULT);
   autoLockMinutes = $state<number>(AUTO_LOCK_DEFAULT_MINUTES);
   closeToTray = $state<boolean>(CLOSE_TO_TRAY_DEFAULT);
+  minimizeToTray = $state<boolean>(MINIMIZE_TO_TRAY_DEFAULT);
   lastActivityAt = $state<number>(Date.now());
   visibleColumns = $state<CipherListColumns>({ ...VISIBLE_COLUMNS_DEFAULT });
 
@@ -93,6 +96,10 @@ export class PrefsController {
       // installs) keeps the hide-to-tray behaviour.
       if (savedTray === "false") {
         this.closeToTray = false;
+      }
+      const savedMinTray = localStorage.getItem(MINIMIZE_TO_TRAY_STORAGE_KEY);
+      if (savedMinTray === "false") {
+        this.minimizeToTray = false;
       }
       const savedColumns = localStorage.getItem(VISIBLE_COLUMNS_STORAGE_KEY);
       if (savedColumns) {
@@ -188,6 +195,15 @@ export class PrefsController {
     this.closeToTray = value;
     try {
       localStorage.setItem(CLOSE_TO_TRAY_STORAGE_KEY, String(value));
+    } catch {
+      // ignore
+    }
+  }
+
+  setMinimizeToTray(value: boolean) {
+    this.minimizeToTray = value;
+    try {
+      localStorage.setItem(MINIMIZE_TO_TRAY_STORAGE_KEY, String(value));
     } catch {
       // ignore
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -118,6 +118,17 @@
     onLock: lockAndReset,
   });
 
+  // Mirror the close-to-tray preference into Rust whenever it
+  // changes (and once on bootstrap, after `prefs.bootstrap()` lands
+  // the localStorage value). The window-event handler reads from
+  // an AtomicBool on AppState, so this keeps the X button's
+  // behaviour in lockstep with the dialog toggle.
+  $effect(() => {
+    api.setCloseToTray(prefs.closeToTray).catch((e) => {
+      console.warn("[clavix] setCloseToTray failed:", e);
+    });
+  });
+
   onMount(async () => {
     prefs.bootstrap();
     await auth.bootstrap({ onboarded: prefs.isOnboarded() });
@@ -272,9 +283,11 @@
     currentLocale={prefs.currentLocale}
     themePref={prefs.themePref}
     autoLockMinutes={prefs.autoLockMinutes}
+    closeToTray={prefs.closeToTray}
     onApplyLocale={(loc) => prefs.applyLocale(loc, { reload: true })}
     onApplyTheme={(t) => prefs.applyTheme(t)}
     onApplyAutoLock={(min) => prefs.setAutoLockMinutes(min)}
+    onApplyCloseToTray={(v) => prefs.setCloseToTray(v)}
     onCopySocketPath={copySshAgentSocket}
   />
 {/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -128,6 +128,11 @@
       console.warn("[clavix] setCloseToTray failed:", e);
     });
   });
+  $effect(() => {
+    api.setMinimizeToTray(prefs.minimizeToTray).catch((e) => {
+      console.warn("[clavix] setMinimizeToTray failed:", e);
+    });
+  });
 
   onMount(async () => {
     prefs.bootstrap();
@@ -284,10 +289,12 @@
     themePref={prefs.themePref}
     autoLockMinutes={prefs.autoLockMinutes}
     closeToTray={prefs.closeToTray}
+    minimizeToTray={prefs.minimizeToTray}
     onApplyLocale={(loc) => prefs.applyLocale(loc, { reload: true })}
     onApplyTheme={(t) => prefs.applyTheme(t)}
     onApplyAutoLock={(min) => prefs.setAutoLockMinutes(min)}
     onApplyCloseToTray={(v) => prefs.setCloseToTray(v)}
+    onApplyMinimizeToTray={(v) => prefs.setMinimizeToTray(v)}
     onCopySocketPath={copySshAgentSocket}
   />
 {/if}


### PR DESCRIPTION
## Summary
- Tray icon, visible while the app runs. Right-click menu: **Ouvrir Clavix** / **Verrouiller maintenant** / **Quitter**. Left-click toggles the main window between hidden and shown.
- X button now hides the window into the tray by default; \`Quitter\` is the only path that tears the process down. Same shape as KeePassXC and Bitwarden Desktop.
- Configurable from Préférences (\`Bouton Fermer\` dropdown) — the renderer mirrors the choice into a Rust \`AtomicBool\` on every change so the close hook always sees the latest value.

## Implementation notes
- \`tauri\` dep gains the \`tray-icon\` feature.
- New \`commands/tray.rs\` owns the tray builder, the window-event hook, and the \`set_close_to_tray\` IPC. Tray setup failure is logged and swallowed (\`build_tray\` is non-fatal) so CI under xvfb still launches.
- Native tray menu strings are hard-coded in French — Paraglide doesn't reach native menus. Documented inline.
- Lock-from-tray inlines the same teardown as \`commands::auth::lock\` (ssh-agent stop, session drop, pending-2FA clear) since we hold an \`AppHandle\`, not the \`State<'_, AppState>\` shape Tauri's dispatcher provides.

## Test plan
- [ ] CI: \`Rust\` (clippy + cargo test --tests, including the integration suite from #46), \`Frontend\` (svelte-check), \`E2E\` (existing specs run inside xvfb where no tray is available — the non-fatal error path keeps them green), \`Smoke release\`.
- [ ] Manual after \`dev-build\` workflow: launch AppImage, verify tray icon, exercise menu items, toggle the Préférences dropdown and confirm the X button changes behaviour without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)