### PR TITLE
feat(tray): localise the tray menu against the user's locale

### DIFF
--- a/src-tauri/src/commands/tray.rs
+++ b/src-tauri/src/commands/tray.rs
@@ -1,20 +1,21 @@
 //! System-tray wiring (issue #38).
 //!
-//! Three responsibilities:
-//!   - `build_tray` constructs the tray icon, its right-click menu
-//!     ("Ouvrir" / "Verrouiller maintenant" / "Quitter") and the
-//!     left-click toggle. Called once from `lib.rs::run` setup.
-//!   - `handle_window_close` interprets `WindowEvent::CloseRequested`
-//!     against the user's `close_to_tray` preference: hide-or-quit.
-//!   - `set_close_to_tray` is the IPC the renderer calls every time
-//!     the preference changes (and on bootstrap, to hydrate the
-//!     Rust mirror from `localStorage`).
-//!
-//! Native menu strings are hard-coded in French. The renderer-side
-//! Paraglide pipeline doesn't reach native menus; supporting English
-//! tray entries would mean reading the user's locale from a config
-//! file at startup and rebuilding the tray on language change. Out
-//! of scope until someone asks.
+//! Four responsibilities:
+//!   - `build_tray` constructs the tray icon, its right-click menu,
+//!     and the left-click toggle. Called once from `lib.rs::run`
+//!     setup. Initial build uses French labels to match the
+//!     codebase default; the renderer follows up with
+//!     `set_tray_locale` once `prefs.bootstrap()` has read the user
+//!     locale from `localStorage`.
+//!   - `handle_window_event` interprets `WindowEvent::CloseRequested`
+//!     against the user's `close_to_tray` preference, and
+//!     `WindowEvent::Resized` against `minimize_to_tray`.
+//!   - `set_close_to_tray` / `set_minimize_to_tray` are the IPCs
+//!     the renderer calls every time the matching preference
+//!     changes (and on bootstrap, to hydrate the Rust mirror).
+//!   - `set_tray_locale` rebuilds the menu strings without
+//!     recreating the tray, so changing the language in Préférences
+//!     swaps the labels live.
 
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
@@ -28,6 +29,32 @@ const ITEM_OPEN: &str = "tray.open";
 const ITEM_LOCK: &str = "tray.lock";
 const ITEM_QUIT: &str = "tray.quit";
 const MAIN_WINDOW: &str = "clavix";
+
+/// Native tray menu labels per locale. Native menus don't go through
+/// Paraglide, so the renderer hands the locale code over IPC and we
+/// pick the matching strings here. Anything we don't recognise falls
+/// back to French — same default the rest of the app uses.
+struct TrayStrings {
+    open: &'static str,
+    lock: &'static str,
+    quit: &'static str,
+}
+
+fn tray_strings(locale: &str) -> TrayStrings {
+    match locale {
+        "en" => TrayStrings {
+            open: "Open Clavix",
+            lock: "Lock now",
+            quit: "Quit",
+        },
+        // "fr" and any unknown locale share the French default.
+        _ => TrayStrings {
+            open: "Ouvrir Clavix",
+            lock: "Verrouiller maintenant",
+            quit: "Quitter",
+        },
+    }
+}
 
 /// Renderer-driven flag that decides what the X button does.
 /// Mirrors `prefs.closeToTray` in `src/lib/prefs.svelte.ts`. The
@@ -67,10 +94,7 @@ pub fn build_tray(app: &AppHandle) {
     };
 
     let result = (|| -> tauri::Result<()> {
-        let open = MenuItem::with_id(app, ITEM_OPEN, "Ouvrir Clavix", true, None::<&str>)?;
-        let lock = MenuItem::with_id(app, ITEM_LOCK, "Verrouiller maintenant", true, None::<&str>)?;
-        let quit = MenuItem::with_id(app, ITEM_QUIT, "Quitter", true, None::<&str>)?;
-        let menu = Menu::with_items(app, &[&open, &lock, &quit])?;
+        let menu = build_menu(app, "fr")?;
 
         TrayIconBuilder::with_id(TRAY_ID)
             .icon(icon)
@@ -103,6 +127,39 @@ pub fn build_tray(app: &AppHandle) {
     if let Err(e) = result {
         eprintln!("[clavix] tray icon setup failed (non-fatal): {e}");
     }
+}
+
+fn build_menu(app: &AppHandle, locale: &str) -> tauri::Result<Menu<tauri::Wry>> {
+    let s = tray_strings(locale);
+    let open = MenuItem::with_id(app, ITEM_OPEN, s.open, true, None::<&str>)?;
+    let lock = MenuItem::with_id(app, ITEM_LOCK, s.lock, true, None::<&str>)?;
+    let quit = MenuItem::with_id(app, ITEM_QUIT, s.quit, true, None::<&str>)?;
+    Menu::with_items(app, &[&open, &lock, &quit])
+}
+
+/// Swap the tray menu strings to match the user's locale.
+///
+/// Called by the renderer on bootstrap (after `prefs.bootstrap()`
+/// reads `clavix.locale` from `localStorage`) and on every locale
+/// change. The whole locale-change flow already does a window
+/// reload, but `setup()` only runs once, so without this IPC the
+/// tray would stay in the language it was built with at process
+/// start. Failure is non-fatal: a tray that's gone (no system
+/// tray on this WM, build_tray skipped earlier) just no-ops.
+#[tauri::command]
+pub fn set_tray_locale(app: AppHandle, locale: String) -> Result<()> {
+    let Some(tray) = app.tray_by_id(TRAY_ID) else {
+        return Ok(());
+    };
+    match build_menu(&app, &locale) {
+        Ok(menu) => {
+            if let Err(e) = tray.set_menu(Some(menu)) {
+                eprintln!("[clavix] tray set_menu failed (non-fatal): {e}");
+            }
+        }
+        Err(e) => eprintln!("[clavix] tray menu rebuild failed (non-fatal): {e}"),
+    }
+    Ok(())
 }
 
 fn show_main_window(app: &AppHandle) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -127,6 +127,7 @@ pub fn run() {
             commands::ssh::ssh_auth_sock,
             commands::tray::set_close_to_tray,
             commands::tray::set_minimize_to_tray,
+            commands::tray::set_tray_locale,
             commands::import::parse_kdbx,
         ])
         .run(tauri::generate_context!())

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -98,6 +98,8 @@ export const api = {
   setMinimizeToTray: (value: boolean) =>
     invoke<void>("set_minimize_to_tray", { value }),
 
+  setTrayLocale: (locale: string) => invoke<void>("set_tray_locale", { locale }),
+
   webauthnSignChallenge: (challengeJson: string) =>
     invoke<string>("webauthn_sign_challenge", { challengeJson }),
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -133,6 +133,15 @@
       console.warn("[clavix] setMinimizeToTray failed:", e);
     });
   });
+  // Hand the user's locale to the tray menu builder so the
+  // Ouvrir / Verrouiller / Quitter strings switch with the
+  // language toggle. Native menus don't go through Paraglide,
+  // hence the dedicated IPC.
+  $effect(() => {
+    api.setTrayLocale(prefs.currentLocale).catch((e) => {
+      console.warn("[clavix] setTrayLocale failed:", e);
+    });
+  });
 
   onMount(async () => {
     prefs.bootstrap();


### PR DESCRIPTION
## Summary
- Native tray menu strings stayed hard-coded in French, since Paraglide doesn't reach native menus. Now the renderer hands the locale code over via a new \`set_tray_locale\` IPC and Rust rebuilds the menu live via \`tray.set_menu(...)\`.
- French (default) and English are wired today: \`Open Clavix\` / \`Lock now\` / \`Quit\` vs. \`Ouvrir Clavix\` / \`Verrouiller maintenant\` / \`Quitter\`. Unknown locales fall back to French.
- \`build_tray\` still uses the French default at process start (the renderer isn't ready in \`setup()\`); the renderer's \`\$effect\` fires \`setTrayLocale\` right after \`prefs.bootstrap()\` lands, so an English user sees the right labels essentially immediately on first open.

## Out of scope
- macOS minimise-to-tray (already documented as best-effort in \`handle_window_event\`): would need \`objc2\` interop for \`NSWindowDidMiniaturizeNotification\`, untestable from CI without a real Mac. Deferred.

## Test plan
- [ ] CI: \`Rust\` (fmt + clippy + audit + test), \`Frontend\`, \`E2E\`, \`Smoke release\`.
- [ ] Manual after \`dev-build\`: launch with \`clavix.locale = "en"\` in localStorage, right-click the tray icon, verify menu reads in English. Toggle language in Préférences → reload → confirm labels switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)