### PR TITLE
fix(security): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4196,9 +4196,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## Contexte

Le job CI `Rust (fmt + clippy + audit)` échoue sur **toutes** les PRs ouvertes (#99–#103), y compris celles purement npm. La cause n'est pas les bumps eux-mêmes mais une vulnérabilité transitive pré-existante sur `master`.

## Vulnérabilité

- **RUSTSEC-2026-0185** — `quinn-proto 0.11.14`
- *Remote memory exhaustion from unbounded out-of-order stream reassembly*
- Sévérité **7.5 (high)** — Solution officielle : `Upgrade to >=0.11.15`

## Changement

`cargo update -p quinn-proto --precise 0.11.15` — diff minimal dans `src-tauri/Cargo.lock` (version + checksum uniquement, dépendances inchangées).

Une fois mergée, un rebase des PRs #99–#103 les fera repasser au vert sur l'audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)