### PR TITLE
fix(security): resolve quick-xml DoS advisories (RUSTSEC-2026-0194/0195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,17 @@ jobs:
       # Notre exposition est faible : déchiffrement d'org keys une fois par sync,
       # HTTPS vers Vaultwarden, pas d'oracle exposé à un attaquant. À retirer dès
       # que le crate `rsa` publie une version constant-time.
+      #
+      # RUSTSEC-2026-0194 / RUSTSEC-2026-0195 : DoS (run time quadratique et
+      # allocation non bornée) dans `quick-xml` < 0.41.0, tiré transitivement par
+      # `wayland-scanner` 0.31.10 (dernière version publiée, pas encore de fix
+      # upstream). `wayland-scanner` génère du code à la compilation à partir de
+      # fichiers XML de protocole *fiables* fournis par les crates wayland : le XML
+      # n'est jamais contrôlé par un attaquant, l'avis ne s'applique pas à notre
+      # usage. La copie vulnérable via `plist` a été corrigée par `plist` 1.10.0.
+      # À retirer dès que `wayland-scanner` passe à `quick-xml` >= 0.41.0.
       - name: cargo audit
-        run: cargo audit --ignore RUSTSEC-2023-0071
+        run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195
 
   frontend:
     name: Frontend (svelte-check)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3937,13 +3937,13 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -4145,15 +4145,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick-xml"


### PR DESCRIPTION
## Contexte

`cargo audit` a fait passer `master` en rouge après la publication le 2026-06-29 de **RUSTSEC-2026-0194** (run time quadratique sur la détection d'attributs dupliqués) et **RUSTSEC-2026-0195** (allocation non bornée de déclarations de namespace → DoS mémoire), toutes deux *high* (7.5), touchant `quick-xml` < 0.41.0.

Ces avis sont **préexistants** (deps transitives) et sans lien avec les bumps Dependabot fraîchement mergés — le run CID les a simplement fait remonter.

## Deux copies vulnérables

| Chemin | Version | Correctif |
|--------|---------|-----------|
| `plist` 1.8.0 | quick-xml 0.38.4 | **Bump `plist` → 1.10.0** (retire 0.38.4 de l'arbre) |
| `wayland-scanner` 0.31.10 | quick-xml 0.39.2 | Pas de fix upstream (0.31.10 = dernière version publiée) → **ignore en CI** |

`wayland-scanner` génère du code à la compilation depuis des fichiers XML de protocole *fiables* fournis par les crates wayland — le XML n'est jamais contrôlé par un attaquant, l'avis DoS ne s'applique pas à notre usage. L'ignore est documenté dans `ci.yml` et à retirer dès que `wayland-scanner` passe à `quick-xml` >= 0.41.0.

## Changements
- `src-tauri/Cargo.lock` : `plist` 1.8.0 → 1.10.0 (quick-xml 0.38.4 supprimé)
- `.github/workflows/ci.yml` : `--ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195` + commentaire justificatif

🤖 Generated with [Claude Code](https://claude.com/claude-code)