### PR TITLE
chore(ci): pin pnpm version via packageManager field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -167,8 +165,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node.js
         uses: actions/setup-node@v6
@@ -249,8 +245,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -38,8 +38,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,8 +75,6 @@ jobs:
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 10
 
       - name: Install Node.js
         uses: actions/setup-node@v6

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.8",
   "description": "Client desktop moderne pour Vaultwarden/Bitwarden",
   "type": "module",
+  "packageManager": "pnpm@10.34.5",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
## Problem

Every Dependabot npm PR (#114, #115, #117, #119, #121) deletes the same 15 `libc: [glibc]` / `libc: [musl]` lines from the `@rolldown/binding-linux-*` entries in `pnpm-lock.yaml` — lines unrelated to the dependency each PR claims to bump. Dependabot is regenerating the lockfile with an older pnpm than the one that wrote it, so it drops metadata it doesn't understand.

Without those fields pnpm can't pick the correct glibc-vs-musl native binding, and every npm PR carries unrelated lockfile churn.

## Fix

- Declare `"packageManager": "pnpm@10.34.5"` in `package.json` so local installs, CI and Dependabot all resolve the same pnpm.
- Drop the `version: 10` input from the five `pnpm/action-setup@v6` steps (ci.yml ×3, release.yml, dev-build.yml) so the action reads the version from `packageManager` instead of pinning a floating major.

pnpm 10 rather than 11 because that's the major CI and Dependabot already run; 10.34.5 is the current 10.x.

## Verification

- Local pnpm (11.4.0) auto-switched to 10.34.5 from the new field.
- `pnpm install` under 10.34.5 leaves `pnpm-lock.yaml` **byte-identical** — the `libc:` fields are preserved, so no churn and nothing to regenerate.
- `pnpm install --frozen-lockfile` ✅ · `pnpm check` → 1025 files, 0 errors ✅ · `pnpm test` → 103/103 passing ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)