### PR TITLE
ci: keep the component name out of release tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "clavix",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": true,
+      "include-component-in-tag": false,
       "draft": false,
       "prerelease": false,
       "extra-files": [


### PR DESCRIPTION
release-please was about to tag `clavix-v0.3.0`. Existing tags are `v0.2.8` / `v0.2.9`, and `release.yml` triggers on `v*`, so the component prefix has to go.

Merging this regenerates the release PR (#126) with the right tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH