### PR TITLE
fix: WebAuthn 2FA never received its challenge, password reveal, stray space in item count

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -192,7 +192,7 @@
   "two_factor_yubikey_help": "Touch your YubiKey to auto-fill the code (44 characters).",
   "two_factor_unsupported": "2FA provider \"{provider}\" is not supported by Clavix yet.",
   "two_factor_webauthn_help": "Plug in your FIDO2 security key (YubiKey, SoloKey, etc.) and tap it once it blinks.",
-  "two_factor_webauthn_no_challenge": "The server didn't return a WebAuthn challenge — this method is unavailable.",
+  "two_factor_webauthn_no_challenge": "The server sent no WebAuthn challenge. Vaultwarden only generates one when its DOMAIN setting is a hostname: with an IP address, WebAuthn is disabled (the spec forbids it). Check DOMAIN on the server, and re-register the key if you change it.",
   "two_factor_webauthn_sign": "Sign with the key",
   "two_factor_webauthn_waiting": "Waiting for your key…",
   "session_title": "Active session",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -192,7 +192,7 @@
   "two_factor_yubikey_help": "Touchez votre YubiKey pour saisir automatiquement le code (44 caractères).",
   "two_factor_unsupported": "Provider 2FA « {provider} » non pris en charge par Clavix pour l'instant.",
   "two_factor_webauthn_help": "Branchez votre clé de sécurité FIDO2 (YubiKey, SoloKey, etc.) puis touchez-la quand elle clignote.",
-  "two_factor_webauthn_no_challenge": "Le serveur n'a pas renvoyé de challenge WebAuthn — impossible de continuer sur cette méthode.",
+  "two_factor_webauthn_no_challenge": "Le serveur n'a pas fourni de challenge WebAuthn. Vaultwarden ne le génère que si son paramètre DOMAIN est un nom de domaine : avec une adresse IP, WebAuthn est désactivé (la spécification l'interdit). Vérifiez DOMAIN côté serveur, puis réenregistrez la clé si vous l'avez modifié.",
   "two_factor_webauthn_sign": "Valider avec la clé",
   "two_factor_webauthn_waiting": "En attente de votre clé…",
   "session_title": "Session active",

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -102,7 +102,19 @@ pub struct LoginOk {
 /// IPC-facing variant of `LoginResult` — same shape as the old type, minus
 /// the `TokenSet` payload that has no business reaching the WebView.
 #[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", content = "data", rename_all = "camelCase")]
+// `rename_all` on an enum renames the *variants*, not the fields inside a
+// struct variant — `rename_all_fields` is what camel-cases those. Without
+// it `webauthn_challenge` crossed the IPC boundary in snake_case while the
+// frontend read `webauthnChallenge`, so the WebAuthn challenge always
+// arrived as `undefined` and 2FA with a security key reported "the server
+// sent no challenge". `providers` never showed the bug: one word, same
+// spelling in both conventions.
+#[serde(
+    tag = "type",
+    content = "data",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
 pub enum LoginOutcome {
     Success(LoginOk),
     TwoFactorRequired {
@@ -560,4 +572,45 @@ pub struct CipherSummary {
     pub username: Option<String>,
     pub revision_date: Option<String>,
     pub deleted_date: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The frontend reads `data.webauthnChallenge`. Serde's `rename_all` on
+    /// an enum only touches variant names, so without `rename_all_fields`
+    /// this field ships as `webauthn_challenge`, the WebView sees
+    /// `undefined`, and logging in with a security key dies on "the server
+    /// sent no WebAuthn challenge" — with the server having sent one.
+    #[test]
+    fn two_factor_outcome_is_camel_cased_for_the_webview() {
+        let json = serde_json::to_value(LoginOutcome::TwoFactorRequired {
+            providers: vec![
+                TwoFactorProvider::Authenticator,
+                TwoFactorProvider::WebAuthn,
+            ],
+            webauthn_challenge: Some("{\"publicKey\":{}}".into()),
+        })
+        .expect("serialise");
+
+        assert_eq!(json["type"], "twoFactorRequired");
+        assert_eq!(json["data"]["webauthnChallenge"], "{\"publicKey\":{}}");
+        assert!(
+            json["data"].get("webauthn_challenge").is_none(),
+            "snake_case field leaked to the IPC boundary: {json}"
+        );
+        assert_eq!(json["data"]["providers"][1], 7);
+    }
+
+    #[test]
+    fn two_factor_outcome_omits_an_absent_challenge() {
+        let json = serde_json::to_value(LoginOutcome::TwoFactorRequired {
+            providers: vec![TwoFactorProvider::Authenticator],
+            webauthn_challenge: None,
+        })
+        .expect("serialise");
+
+        assert!(json["data"].get("webauthnChallenge").is_none());
+    }
 }

--- a/src/lib/AuthLoginForm.svelte
+++ b/src/lib/AuthLoginForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as m from "$lib/paraglide/messages";
+  import PasswordInput from "./PasswordInput.svelte";
 
   type Props = {
     serverUrl: string;
@@ -35,7 +36,7 @@
   </label>
   <label>
     {m.form_master_password()}
-    <input type="password" bind:value={password} required {disabled} />
+    <PasswordInput bind:value={password} required {disabled} />
   </label>
   <button type="submit" {disabled}>
     {disabled ? m.action_signing_in() : m.action_sign_in()}

--- a/src/lib/CipherList.svelte
+++ b/src/lib/CipherList.svelte
@@ -125,10 +125,9 @@
 <section class="list-pane">
   <h3>
     Items
-    <small>
-      ({items.length.toLocaleString("fr-FR")}
-      {#if hasNarrowing}/{totalCount.toLocaleString("fr-FR")}{/if})
-    </small>
+    <!-- Kept on one line: a newline before `)` renders as a stray space,
+         which showed up as "(3 319 )" whenever nothing narrowed the list. -->
+    <small>({items.length.toLocaleString("fr-FR")}{#if hasNarrowing}/{totalCount.toLocaleString("fr-FR")}{/if})</small>
   </h3>
   <div class="search-row">
     <input

--- a/src/lib/PasswordInput.svelte
+++ b/src/lib/PasswordInput.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+  import * as m from "$lib/paraglide/messages";
+  import Icon from "./Icon.svelte";
+
+  // A password field with a reveal toggle sitting inside its right edge.
+  // Typing a master password blind is exactly where a typo costs the most
+  // (a failed unlock says nothing about *why*), so every password entry
+  // point in the app goes through this rather than a bare <input>.
+  let {
+    value = $bindable(),
+    required = false,
+    disabled = false,
+    autocomplete = "current-password",
+    id = undefined,
+  }: {
+    value: string;
+    required?: boolean;
+    disabled?: boolean;
+    autocomplete?: AutoFill;
+    id?: string;
+  } = $props();
+
+  let revealed = $state(false);
+</script>
+
+<div class="password-input">
+  <input
+    {id}
+    type={revealed ? "text" : "password"}
+    bind:value
+    {required}
+    {disabled}
+    {autocomplete}
+  />
+  <button
+    type="button"
+    class="reveal"
+    onclick={() => (revealed = !revealed)}
+    disabled={disabled}
+    title={revealed ? m.action_hide() : m.action_show()}
+    aria-label={revealed ? m.action_hide() : m.action_show()}
+    aria-pressed={revealed}
+    tabindex="-1"
+  >
+    <Icon name={revealed ? "eye-off" : "eye"} size={16} />
+  </button>
+</div>
+
+<style>
+  .password-input {
+    position: relative;
+    display: block;
+  }
+
+  .password-input input {
+    width: 100%;
+    /* Room for the button so a long password never slides under it. */
+    padding-right: 2.2rem;
+  }
+
+  .reveal {
+    position: absolute;
+    top: 50%;
+    right: 0.35rem;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem;
+    border: none;
+    background: none;
+    color: #666;
+    cursor: pointer;
+    border-radius: 4px;
+  }
+
+  .reveal:hover:not(:disabled) {
+    color: #163b8a;
+    background: #eef3ff;
+  }
+
+  .reveal:disabled {
+    cursor: default;
+    opacity: 0.5;
+  }
+</style>

--- a/src/lib/UnlockForm.svelte
+++ b/src/lib/UnlockForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import * as m from "$lib/paraglide/messages";
+  import PasswordInput from "./PasswordInput.svelte";
   import type { StoredAccount } from "./types";
 
   type Props = {
@@ -35,7 +36,7 @@
   <form onsubmit={onSubmit}>
     <label>
       {m.form_master_password()}
-      <input type="password" bind:value={password} required {disabled} />
+      <PasswordInput bind:value={password} required {disabled} />
     </label>
     <div class="row">
       <button type="button" class="secondary" onclick={onSwitchAccount}>{m.action_logout()}</button>


### PR DESCRIPTION
Three fixes.

## Logging in with a security key was impossible

`serde`'s `rename_all` on an enum renames the *variants*, not the fields inside a struct variant — that needs `rename_all_fields`. So `LoginOutcome::TwoFactorRequired` shipped `webauthn_challenge` in snake_case across the IPC boundary while the frontend read `webauthnChallenge`. The challenge arrived as `undefined` every single time, and the app blamed the server: *"the server sent no WebAuthn challenge"* — with the server having sent one.

`providers` hid the bug: one word, identical in both conventions, so the 2FA screen looked healthy and cheerfully offered the security key. WebAuthn 2FA has therefore never worked, for anyone.

Two tests now pin the IPC contract, and both were confirmed to fail without the fix.

The no-challenge message is rewritten too: it was true but useless. The real server-side cause is a `DOMAIN` set to an IP address — the WebAuthn spec forbids IPs as an RP ID, so Vaultwarden silently skips challenge generation while still advertising the provider.

## `(3 319 )`

The closing paren sat on its own template line; Svelte keeps the newline as a space.

## Password reveal

An eye toggle inside the password field, on the login and unlock forms. Typing a master password blind is where a typo costs the most: a failed unlock never says why. The field still reports `type=password` while hidden, so the E2E selectors that drive it are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH