### PR TITLE
fix: YubiKey 2FA login (CTAP2 uv option) + notify UI on backend auto-lock

### DIFF
--- a/src-tauri/src/commands/tray.rs
+++ b/src-tauri/src/commands/tray.rs
@@ -32,7 +32,7 @@ const ITEM_QUIT: &str = "tray.quit";
 /// to `unlock` and clears the vault when this fires, so the UI
 /// catches up with the session that the tray menu just dropped on
 /// the Rust side. Payload-less; the event itself is the signal.
-const EVENT_SESSION_LOCKED: &str = "clavix:session-locked";
+pub(crate) const EVENT_SESSION_LOCKED: &str = "clavix:session-locked";
 // Tauri 2 assigns label "main" to a window declared in tauri.conf.json
 // without an explicit `label` field — see tauri-utils
 // `default_window_label`. The capability in

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,7 @@ mod yubikey_unlock;
 
 use std::time::Duration;
 
-use tauri::Manager;
+use tauri::{Emitter, Manager};
 
 use state::AppState;
 
@@ -76,10 +76,31 @@ pub fn run() {
                     if let Some(h) = agent {
                         h.stop().await;
                     }
-                    let mut session_guard = state.session.lock();
-                    if session_guard.is_some() {
-                        *session_guard = None;
-                        eprintln!("[clavix] session auto-locked after {minutes} min idle");
+                    let locked = {
+                        let mut session_guard = state.session.lock();
+                        if session_guard.is_some() {
+                            *session_guard = None;
+                            eprintln!("[clavix] session auto-locked after {minutes} min idle");
+                            true
+                        } else {
+                            false
+                        }
+                    };
+                    // Mirror the tray "Verrouiller maintenant" path: tell the
+                    // WebView the session is gone so it leaves the vault view
+                    // at once. Without this the backend drops the session
+                    // silently and the UI keeps showing a stale list until the
+                    // next IPC call fails with `not_authenticated` — which is
+                    // exactly the "connexion perdue, plus rien ne marche"
+                    // dead-end users hit after a 10-min idle window.
+                    if locked {
+                        if let Err(e) =
+                            handle.emit(crate::commands::tray::EVENT_SESSION_LOCKED, ())
+                        {
+                            eprintln!(
+                                "[clavix] emit session-locked after auto-lock failed (non-fatal): {e}"
+                            );
+                        }
                     }
                 }
             });

--- a/src-tauri/src/webauthn.rs
+++ b/src-tauri/src/webauthn.rs
@@ -219,7 +219,15 @@ fn ctap_assertion(rp_id: &str, hash: &[u8; 32], ids: Vec<Vec<u8>>) -> Result<Ass
         reason: format!("no FIDO2 device available: {e}"),
     })?;
 
-    let mut builder = GetAssertionArgsBuilder::new(rp_id, hash);
+    // `GetAssertionArgs::default()` ships `uv: Some(true)`, so the builder
+    // would put `{ up: true, uv: true }` in the CTAP2 options map. A standard
+    // YubiKey (5-series, no on-device biometric) does not implement the `uv`
+    // option and answers CTAP2_ERR_UNSUPPORTED_OPTION (0x2B) — which is exactly
+    // the failure users hit logging in with their key. WebAuthn used as a
+    // *second factor* only needs user presence (a touch); Vaultwarden requests
+    // `userVerification: "discouraged"` and never inspects the UV flag. So drop
+    // the `uv` option entirely and let the key assert on touch alone.
+    let mut builder = GetAssertionArgsBuilder::new(rp_id, hash).without_pin_and_uv();
     for id in ids {
         builder = builder.credential_id(&id);
     }


### PR DESCRIPTION
Two independent failures a user hit right after a connection drop. Both are `fix` commits → **v0.3.2 patch**.

## 1. YubiKey 2FA login failed — `CTAP2_ERR_UNSUPPORTED_OPTION` (0x2B)

`ctap-hid-fido2`'s `GetAssertionArgs::default()` sets `uv: Some(true)`, so the get_assertion options map carried `uv: true`. A standard YubiKey (5-series, no on-device biometric) does not implement the CTAP2 `uv` option and rejects the request with 0x2B.

WebAuthn as a **second factor** only needs user presence (a touch); Vaultwarden requests `userVerification: "discouraged"` and never inspects the UV flag. Fix: build the assertion with `without_pin_and_uv()` so `uv` is omitted.

This is the missing half of the WebAuthn 2FA story: v0.3.1 fixed the challenge field name so the key prompt appeared; this fixes the assertion itself so the key actually authenticates.

## 2. Connection loss → "Aucune session active", nothing works

Not the network directly. The backend **auto-lock watchdog** (default 10 min idle) dropped the in-memory session but — unlike the tray "Verrouiller maintenant" path — never notified the WebView. The UI kept showing the cached vault and the next IPC call failed with `not_authenticated`: a frozen-looking list where every click errors.

Fix: emit `clavix:session-locked` from the watchdog after nulling the session, so the existing renderer listener locks the UI and lands the user on the unlock screen at once.

## Verification
- `cargo clippy --all-targets -D warnings` ✓
- `cargo test --tests` ✓ (143 lib + integration)
- `cargo fmt --check` ✓

The FIDO2 `get_assertion` path is device-gated (`#[cfg(...)]`) so it can't be unit-tested without hardware — confirmed by reading the CTAP2 spec (§ unsupported `uv` option → 0x2B) and the crate's default. Needs a real-key retest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH