### PR TITLE
feat(list): show keyboard shortcuts in the row context menu

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -467,26 +467,30 @@
     style="left: {menuX}px; top: {menuY}px;"
   >
     <button type="button" role="menuitem" onclick={openMenuCipher}>
-      {m.ctx_open()}
+      <span class="ctx-label">{m.ctx_open()}</span>
     </button>
     {#if menuCipher.username}
       <button type="button" role="menuitem" onclick={copyMenuUsername}>
-        {m.ctx_copy_username()}
+        <span class="ctx-label">{m.ctx_copy_username()}</span>
+        <kbd class="ctx-shortcut">Ctrl+B</kbd>
       </button>
     {/if}
     {#if menuDetail?.login?.password}
       <button type="button" role="menuitem" onclick={copyMenuPassword}>
-        {m.ctx_copy_password()}
+        <span class="ctx-label">{m.ctx_copy_password()}</span>
+        <kbd class="ctx-shortcut">Ctrl+C</kbd>
       </button>
     {/if}
     {#if menuDetail?.login?.totp}
       <button type="button" role="menuitem" onclick={copyMenuTotp}>
-        {m.ctx_copy_totp()}
+        <span class="ctx-label">{m.ctx_copy_totp()}</span>
+        <kbd class="ctx-shortcut">Ctrl+T</kbd>
       </button>
     {/if}
     {#if menuCipher.primaryUri}
       <button type="button" role="menuitem" onclick={openMenuUri}>
-        {m.ctx_open_url()}
+        <span class="ctx-label">{m.ctx_open_url()}</span>
+        <kbd class="ctx-shortcut">Ctrl+U</kbd>
       </button>
     {/if}
   </div>

--- a/src/styles/cipher-list.css
+++ b/src/styles/cipher-list.css
@@ -397,6 +397,10 @@
 }
 
 .ctx-menu button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.75rem;
   background: transparent;
   border: none;
   padding: 0.4rem 0.6rem;
@@ -411,10 +415,30 @@
   background: #eef2fa;
 }
 
+.ctx-label {
+  white-space: nowrap;
+}
+
+/* Right-aligned keyboard hint. Muted, tabular monospace so the modifier
+   keys read cleanly and line up down the menu. */
+.ctx-shortcut {
+  margin-left: auto;
+  font-family: var(--font-data, ui-monospace, monospace);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: #8a8f98;
+  background: #f1f3f7;
+  border: 1px solid #e2e5eb;
+  border-radius: 4px;
+  padding: 0.05rem 0.35rem;
+}
+
 @media (prefers-color-scheme: dark) {
   .ctx-menu { background: #2a2a2a; border-color: #444; }
   .ctx-menu button:hover { background: #2c3a55; }
+  .ctx-shortcut { color: #9aa0aa; background: #33383f; border-color: #454b54; }
 }
 
 :root.force-dark .ctx-menu { background: #2a2a2a; border-color: #444; }
 :root.force-dark .ctx-menu button:hover { background: #2c3a55; }
+:root.force-dark .ctx-shortcut { color: #9aa0aa; background: #33383f; border-color: #454b54; }


### PR DESCRIPTION
Adds a right-aligned, muted monospace badge with the keyboard shortcut next to each context-menu action (Ctrl+B / Ctrl+C / Ctrl+T / Ctrl+U for Copy username / password / TOTP / Open URL). "Ouvrir" has no badge (no Ctrl shortcut). Styled for light + dark themes; preview approved by the user.

## Verification
- `pnpm check` (svelte-check) — 0 errors ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH