### PR TITLE
UI polish: fix invisible export dialog, colored passwords, audit start button, tinted clipboard toast

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -153,6 +153,7 @@
   "audit_label": "Security audit",
   "audit_title": "Security audit",
   "audit_privacy_note": "Checks your passwords against HIBP using k-anonymity: only 5 hex characters of the SHA-1 hash ever leave your machine — never the password itself.",
+  "audit_start": "Run audit",
   "audit_running": "Running… (querying HIBP API)",
   "audit_checked": "{count} password(s) checked.",
   "audit_no_pwned": "No compromised passwords detected.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -153,6 +153,7 @@
   "audit_label": "Audit de sécurité",
   "audit_title": "Audit de sécurité",
   "audit_privacy_note": "Vérifie vos mots de passe contre HIBP via k-anonymity : seuls 5 caractères hex du SHA-1 quittent votre poste, jamais le mot de passe lui-même.",
+  "audit_start": "Lancer l'audit",
   "audit_running": "Analyse en cours… (interrogation de l'API HIBP)",
   "audit_checked": "{count} mot(s) de passe vérifié(s).",
   "audit_no_pwned": "Aucun mot de passe compromis détecté.",

--- a/src/lib/AuditDialog.svelte
+++ b/src/lib/AuditDialog.svelte
@@ -29,9 +29,14 @@
     }
   }
 
-  export async function open() {
+  export function open() {
+    // Don't auto-run: the audit sends every password's hash prefix to
+    // HaveIBeenPwned, so let the user read the privacy note and start it
+    // deliberately.
+    error = null;
+    result = null;
+    loading = false;
     dialog?.showModal();
-    await run();
   }
 
   function close() {
@@ -57,7 +62,10 @@
     <p class="hint audit-privacy">{m.audit_privacy_note()}</p>
 
     {#if loading}
-      <p>{m.audit_running()}</p>
+      <div class="audit-running">
+        <span class="audit-spinner" aria-hidden="true"></span>
+        <span>{m.audit_running()}</span>
+      </div>
     {:else if error}
       <p class="audit-error">{error}</p>
       <div class="row">
@@ -124,6 +132,39 @@
           {/each}
         </ul>
       {/if}
+    {:else}
+      <div class="row audit-start-row">
+        <button type="button" onclick={run}>{m.audit_start()}</button>
+      </div>
     {/if}
   {/key}
 </dialog>
+
+<style>
+  .audit-running {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    margin: 0.6rem 0;
+  }
+
+  .audit-spinner {
+    width: 1.05rem;
+    height: 1.05rem;
+    border: 2px solid #c7d2fe;
+    border-top-color: #396cd8;
+    border-radius: 50%;
+    animation: audit-spin 0.7s linear infinite;
+    flex: none;
+  }
+
+  @keyframes audit-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .audit-start-row {
+    margin-top: 0.4rem;
+  }
+</style>

--- a/src/lib/CipherEditor.svelte
+++ b/src/lib/CipherEditor.svelte
@@ -757,6 +757,15 @@
     flex: 1;
   }
 
+  /* Monospace so a revealed password / TOTP secret reads cleanly (1 vs l,
+     0 vs O). Per-character colouring isn't possible inside an editable
+     <input>; the read-only detail view handles that. */
+  .password-row input,
+  .totp-row input {
+    font-family: "Atkinson Hyperlegible", ui-monospace, monospace;
+    letter-spacing: 0.04em;
+  }
+
   .two-col {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/src/lib/ClipboardToast.svelte
+++ b/src/lib/ClipboardToast.svelte
@@ -10,7 +10,7 @@
 </script>
 
 {#if clipboard.secondsLeft !== null}
-  <aside class="clipboard-toast" role="status">
+  <aside class="clipboard-toast variant-{clipboard.variant}" role="status">
     <span>
       {m.clipboard_toast({
         label: clipboard.label ?? "",
@@ -25,11 +25,13 @@
 
 <style>
   .clipboard-toast {
+    /* Accent tints by copied kind (set via the variant-* classes). */
+    --toast-accent: #1e3a8a;
     position: fixed;
     bottom: 1rem;
     left: 50%;
     transform: translateX(-50%);
-    background: #1e3a8a;
+    background: var(--toast-accent);
     color: #fff;
     padding: 0.6rem 1rem;
     border-radius: 8px;
@@ -40,9 +42,22 @@
     z-index: 1000;
   }
 
+  .clipboard-toast.variant-password {
+    --toast-accent: #1e3a8a;
+  }
+  .clipboard-toast.variant-username {
+    --toast-accent: #0f766e;
+  }
+  .clipboard-toast.variant-totp {
+    --toast-accent: #6d28d9;
+  }
+  .clipboard-toast.variant-default {
+    --toast-accent: #334155;
+  }
+
   .clipboard-toast button.secondary {
     background: #fff;
-    color: #1e3a8a;
+    color: var(--toast-accent);
     border-color: #fff;
     cursor: pointer;
     font: inherit;

--- a/src/lib/GeneratorDialog.svelte
+++ b/src/lib/GeneratorDialog.svelte
@@ -39,6 +39,15 @@
   function close() {
     dialog?.close();
   }
+
+  // Same character-class colouring as the item detail view (global
+  // `.password .ch-*` styles): digits blue, symbols red, letters default,
+  // in a monospace face so `1`/`l` and `0`/`O` are distinguishable.
+  function charClass(ch: string): string {
+    if (/\d/.test(ch)) return "ch-digit";
+    if (/[a-zA-Z]/.test(ch)) return "ch-letter";
+    return "ch-symbol";
+  }
 </script>
 
 <dialog bind:this={dialog} class="stats-dialog">
@@ -51,7 +60,11 @@
     </header>
 
     <div class="generator-output">
-      <code>{output || "—"}</code>
+      {#if output}
+        <code class="password">{#each [...output] as ch, i (i)}<span class={charClass(ch)}>{ch}</span>{/each}</code>
+      {:else}
+        <code>—</code>
+      {/if}
     </div>
     {#if error}
       <p class="hint error-text">{error}</p>

--- a/src/lib/clipboard.svelte.ts
+++ b/src/lib/clipboard.svelte.ts
@@ -2,20 +2,25 @@ import { clear as clearClipboard, writeText } from "@tauri-apps/plugin-clipboard
 
 export const CLIPBOARD_CLEAR_SECONDS = 30;
 
+/** Copied-value kind, used to tint the clipboard toast. */
+export type ClipboardVariant = "password" | "username" | "totp" | "default";
+
 export class ClipboardController {
   secondsLeft = $state<number | null>(null);
   label = $state<string | null>(null);
+  variant = $state<ClipboardVariant>("default");
   private timeout: ReturnType<typeof setTimeout> | null = null;
   private interval: ReturnType<typeof setInterval> | null = null;
 
-  async copy(value: string, label: string): Promise<void> {
+  async copy(value: string, label: string, variant: ClipboardVariant = "default"): Promise<void> {
     await writeText(value);
-    this.scheduleClear(label);
+    this.scheduleClear(label, variant);
   }
 
-  scheduleClear(label: string) {
+  scheduleClear(label: string, variant: ClipboardVariant = "default") {
     this.clearTimers();
     this.label = label;
+    this.variant = variant;
     this.secondsLeft = CLIPBOARD_CLEAR_SECONDS;
     this.interval = setInterval(() => {
       if (this.secondsLeft !== null && this.secondsLeft > 0) {
@@ -30,6 +35,7 @@ export class ClipboardController {
       }
       this.secondsLeft = null;
       this.label = null;
+      this.variant = "default";
       this.clearTimers();
     }, CLIPBOARD_CLEAR_SECONDS * 1000);
   }
@@ -43,6 +49,7 @@ export class ClipboardController {
     }
     this.secondsLeft = null;
     this.label = null;
+    this.variant = "default";
   }
 
   dispose() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,7 +13,7 @@
   import GeneratorDialog from "$lib/GeneratorDialog.svelte";
   import StatsDialog from "$lib/StatsDialog.svelte";
   import AuditDialog from "$lib/AuditDialog.svelte";
-  import { ClipboardController } from "$lib/clipboard.svelte";
+  import { ClipboardController, type ClipboardVariant } from "$lib/clipboard.svelte";
   import { DragController } from "$lib/drag.svelte";
   import { AuthController } from "$lib/auth.svelte";
   import { VaultController } from "$lib/vault.svelte";
@@ -69,9 +69,20 @@
     }
   });
 
+  // Tint the clipboard toast by what was copied. Nearly every copy funnels
+  // through here, so deriving the kind from the label keeps the call sites
+  // untouched; anything unrecognised (URLs, SSH socket, …) stays the default.
+  function clipboardVariant(label: string): ClipboardVariant {
+    const l = label.toLowerCase();
+    if (l.includes("passe") || l.includes("password")) return "password";
+    if (l.includes("totp") || l.includes("otp")) return "totp";
+    if (l.includes("identifiant") || l.includes("username")) return "username";
+    return "default";
+  }
+
   async function copyToClipboard(value: string, label: string) {
     try {
-      await clipboard.copy(value, label);
+      await clipboard.copy(value, label, clipboardVariant(label));
     } catch (e) {
       vault.error = formatError(e);
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -42,7 +42,7 @@
 
   let searchInput: HTMLInputElement | null = null;
   let statsDialog = $state<{ open: () => Promise<void> } | null>(null);
-  let auditDialog = $state<{ open: () => Promise<void> } | null>(null);
+  let auditDialog = $state<{ open: () => void } | null>(null);
   let generatorDialog = $state<{ open: () => void } | null>(null);
   let importOpen = $state(false);
   let exportOpen = $state(false);

--- a/src/styles/dialogs.css
+++ b/src/styles/dialogs.css
@@ -306,3 +306,54 @@
 :root.force-dark .stats-dialog { background: #2b2b2b; color: #f6f6f6; }
 :root.force-dark .generator-output { background: #1e1e1e; }
 :root.force-dark .error-text { color: #ff8a8a; }
+
+/* Shared modal-dialog shell for ImportDialog and ExportDialog. These used
+   to live only in ImportDialog's scoped <style>, so ExportDialog referenced
+   `.import-backdrop`/`.import-panel` with no styles behind them and rendered
+   invisibly (no backdrop, no positioning) — the "export shows nothing" bug.
+   Hoisted here so both dialogs share one definition. */
+.import-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 150;
+}
+
+.import-panel {
+  background: #fff;
+  border-radius: 10px;
+  padding: 1.1rem 1.4rem;
+  width: min(640px, 96vw);
+  max-height: 92vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.import-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.import-header h2 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.import-progress {
+  margin: 0.5rem 0;
+  font-size: 0.9rem;
+}
+
+.import-error {
+  color: #7a1d1d;
+  background: #fdecec;
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  margin: 0.5rem 0;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
A batch of UX improvements headed for v0.5.0.

- **fix(export)**: the export dialog referenced `.import-backdrop`/`.import-panel` which only existed in ImportDialog's *scoped* styles, so it rendered invisibly — "Export shows nothing". Hoisted the shared modal shell to global `dialogs.css`.
- **feat(ui)**: generator password shown in monospace with per-character colouring (digits/symbols), reusing the detail-view classes; editor password/TOTP inputs get the monospace face.
- **feat(audit)**: security audit no longer auto-runs on open — a "Lancer l'audit" button + a running spinner (it sends hash prefixes to HIBP, so the user starts it deliberately).
- **feat(ui)**: clipboard toast tinted by copied kind — password (blue) / username (teal) / TOTP (violet) / other (slate), derived centrally from the copy label.

## Verification
- `pnpm check` — 0 errors ✓ · `pnpm test` — 126 passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH