### PR TITLE
chore(security): disable unused withGlobalTauri

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,7 +10,7 @@
     "frontendDist": "../build"
   },
   "app": {
-    "withGlobalTauri": true,
+    "withGlobalTauri": false,
     "windows": [
       {
         "title": "clavix",


### PR DESCRIPTION
`window.__TAURI__` is never referenced by the frontend (all IPC uses `@tauri-apps/api` imports), so `withGlobalTauri: true` only enlarges the surface a compromised WebView script could reach. Set it to `false`.

Validated by the **Smoke E2E (release build)** job (hydration + login under the release build).

First of the "quick" items from the security review; strict CSP and the deeper command/crypto audit follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH