### PR TITLE
fix(security): tighten CSP connect-src to close the WebView exfiltration channel

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -33,8 +33,20 @@ const config = {
         "default-src": ["self", "ipc:", "http://ipc.localhost"],
         "script-src": ["self"],
         "style-src": ["self", "unsafe-inline"],
-        "img-src": ["self", "data:", "blob:", "https:", "http:"],
-        "connect-src": ["self", "ipc:", "http://ipc.localhost", "https:", "http:"],
+        // The WebView never issues an outbound fetch/WebSocket: every
+        // Vaultwarden request is proxied by the Rust `reqwest` client over
+        // IPC. Dropping `https:`/`http:` from connect-src closes the trivial
+        // exfiltration channel a compromised WebView (XSS or a bad npm dep)
+        // would otherwise use to POST the decrypted vault, tokens and SSH
+        // private keys to any host. This is the highest-leverage containment
+        // fix from the security review (M1).
+        "connect-src": ["self", "ipc:", "http://ipc.localhost"],
+        // `https:` stays here on purpose: favicons load as <img> from the
+        // user's own Vaultwarden server (`${serverUrl}/icons/<domain>/icon.png`,
+        // an arbitrary user-configured HTTPS host we can't hardcode). `http:`
+        // is dropped — favicons are https-only. An <img> beacon is a much
+        // weaker, GET-only, no-response-read channel than connect-src.
+        "img-src": ["self", "data:", "blob:", "https:"],
         "font-src": ["self", "data:"],
         "object-src": ["none"],
         "frame-ancestors": ["none"],


### PR DESCRIPTION
**Finding M1** from the security review (artifact: multi-agent review, 18 verified findings). Highest-leverage containment fix, small diff.

The meta CSP allowed `connect-src … https: http:`, but the WebView issues **zero** direct network calls — all Vaultwarden traffic is proxied by the Rust `reqwest` client over IPC. Those wildcards handed a compromised WebView (XSS / malicious dependency) a trivial channel to `fetch()`/WebSocket the decrypted vault, tokens and SSH private keys to any host.

- `connect-src` → `'self' ipc: http://ipc.localhost` (drop `https:`/`http:`)
- `img-src` → drop `http:`, **keep `https:`** — favicons load as `<img>` from the user's own Vaultwarden HTTPS server (`${serverUrl}/icons/…`); an `<img>` beacon is a far weaker GET-only, no-response-read channel.

Hash-mode `script-src` is untouched (inline bootstrap still whitelisted), so no blank-window regression. Verified locally: `pnpm build` emits `connect-src 'self' ipc: http://ipc.localhost` with the script hash intact. The **Smoke E2E (release build)** job asserts the release window renders — the guard for CSP regressions.

Part of the security-review fix sequence; M2 (bind prelogin/login to the stored server) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH