### PR TITLE
fix(security): session & at-rest hygiene batch (M5, L4, L5, L6, L8)

### DIFF
--- a/src-tauri/src/cache.rs
+++ b/src-tauri/src/cache.rs
@@ -13,6 +13,22 @@ fn data_dir() -> Result<PathBuf> {
     fs::create_dir_all(&dir).map_err(|e| Error::Storage {
         reason: format!("create data dir {}: {e}", dir.display()),
     })?;
+
+    // Restrict the whole data directory to the owner. This is the strongest
+    // and simplest at-rest control: it blocks a second local user/process from
+    // reading *anything* inside — the encrypted vault DB, its transient
+    // journal/WAL sidecars, and session.json — regardless of each file's own
+    // mode.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&dir, fs::Permissions::from_mode(0o700)).map_err(|e| {
+            Error::Storage {
+                reason: format!("restrict data dir {} to 0700: {e}", dir.display()),
+            }
+        })?;
+    }
+
     Ok(dir)
 }
 
@@ -22,15 +38,37 @@ fn db_path() -> Result<PathBuf> {
 
 fn open() -> Result<Connection> {
     let path = db_path()?;
+
+    // Create the DB file 0600 atomically when it is absent, so it never briefly
+    // exists at the umask default (0644) in the window before the chmod below —
+    // the race the old `Connection::open` + best-effort chmod left open.
+    #[cfg(unix)]
+    if !path.exists() {
+        use std::os::unix::fs::OpenOptionsExt;
+        fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(&path)
+            .map_err(|e| Error::Storage {
+                reason: format!("create vault cache db at {}: {e}", path.display()),
+            })?;
+    }
+
     let conn = Connection::open(&path).map_err(|e| Error::Storage {
         reason: format!("open vault cache db at {}: {e}", path.display()),
     })?;
 
+    // Fix up the mode for a DB created by an older build (0644). Best-effort,
+    // but log rather than silently swallow — the 0700 data dir is the real
+    // guarantee.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let perms = fs::Permissions::from_mode(0o600);
-        let _ = fs::set_permissions(&path, perms);
+        if let Err(e) = fs::set_permissions(&path, fs::Permissions::from_mode(0o600)) {
+            eprintln!("[clavix] could not chmod vault cache db to 0600: {e}");
+        }
     }
 
     conn.execute(

--- a/src-tauri/src/commands/ssh.rs
+++ b/src-tauri/src/commands/ssh.rs
@@ -98,14 +98,17 @@ pub async fn start_ssh_agent(state: State<'_, AppState>) -> Result<SshAgentStatu
                 // Surface the underlying message verbatim so the user
                 // understands what to do (re-open the cipher to decrypt it,
                 // or fix a malformed PEM).
-                eprintln!("[clavix agent] skipping '{name}': {reason}");
+                // Don't log the decrypted item name — it's vault-content
+                // metadata that would land in stderr/journald. The name still
+                // reaches the user via the returned `SkippedKey` list.
+                eprintln!("[clavix agent] skipping a key: {reason}");
                 skipped.push(SkippedKey {
                     name: name.clone(),
                     reason,
                 });
             }
             Err(e) => {
-                eprintln!("[clavix agent] skipping '{name}': {e}");
+                eprintln!("[clavix agent] skipping a key: {e}");
                 skipped.push(SkippedKey {
                     name: name.clone(),
                     reason: e.to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,10 @@ pub fn run() {
                 loop {
                     tokio::time::sleep(Duration::from_secs(30)).await;
                     let state = handle.state::<AppState>();
+                    // Wipe an abandoned 2FA prompt's master-key material once it
+                    // outlives its TTL — runs every tick, independent of the
+                    // auto-lock config below.
+                    crate::services::auth::clear_pending_two_factor_if_stale(&state);
                     let Some(minutes) = *state.auto_lock_minutes.lock() else {
                         continue;
                     };
@@ -76,6 +80,9 @@ pub fn run() {
                     if let Some(h) = agent {
                         h.stop().await;
                     }
+                    // Idle threshold reached: also drop any pending 2FA slot so
+                    // the master key never survives the lock.
+                    crate::services::auth::clear_pending_two_factor(&state);
                     let locked = {
                         let mut session_guard = state.session.lock();
                         if session_guard.is_some() {

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 // ============ Prelogin ============
 
@@ -52,16 +53,26 @@ impl TryFrom<u8> for TwoFactorProvider {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// ZeroizeOnDrop wipes the access + refresh tokens (and the wrapped key
+// material) from memory when a Session is torn down (lock / logout /
+// auto-lock), instead of leaving them readable in freed heap for a
+// core-dump/swap attacker. Mirrors the ZeroizeOnDrop the key types already
+// carry. (String zeroization without mlock is best-effort, so this is
+// defense-in-depth.)
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenSet {
+    // The four secret fields are zeroized on drop; the rest are non-secret
+    // metadata (and `KdfType` doesn't implement Zeroize), so they're skipped.
     #[serde(rename = "access_token")]
     pub access_token: String,
     #[serde(rename = "refresh_token")]
     pub refresh_token: String,
     #[serde(rename = "expires_in")]
+    #[zeroize(skip)]
     pub expires_in: u64,
     #[serde(rename = "token_type")]
+    #[zeroize(skip)]
     pub token_type: String,
 
     #[serde(default, alias = "Key")]
@@ -69,8 +80,10 @@ pub struct TokenSet {
     #[serde(default, alias = "PrivateKey")]
     pub private_key: Option<String>,
     #[serde(default, alias = "Kdf")]
+    #[zeroize(skip)]
     pub kdf: Option<KdfType>,
     #[serde(default, alias = "KdfIterations")]
+    #[zeroize(skip)]
     pub kdf_iterations: Option<u32>,
 }
 

--- a/src-tauri/src/services/auth.rs
+++ b/src-tauri/src/services/auth.rs
@@ -179,6 +179,23 @@ pub fn clear_pending_two_factor(state: &AppState) {
     *slot = None;
 }
 
+/// Drop the pending 2FA slot if it has outlived its TTL. The slot holds the
+/// master key + password hash; `with_pending_two_factor` only enforces the TTL
+/// lazily on the next IPC read, so a user who triggers a 2FA prompt and walks
+/// away would otherwise leave that material in memory indefinitely. The
+/// auto-lock watchdog calls this every tick so an abandoned prompt is wiped
+/// even when auto-lock is disabled or the idle window hasn't elapsed.
+pub fn clear_pending_two_factor_if_stale(state: &AppState) {
+    let mut slot = state.pending_2fa.lock();
+    let stale = slot
+        .as_ref()
+        .map(|p| p.created_at.elapsed() > Duration::from_secs(PENDING_2FA_TTL_SECS))
+        .unwrap_or(false);
+    if stale {
+        *slot = None;
+    }
+}
+
 /// Borrow the pending 2FA slot for a single async section. Returns an
 /// error when nothing is pending or when the slot has gone stale past
 /// the TTL — the stale path zeroizes the slot on the way out.

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -97,10 +97,21 @@ pub fn load_session() -> Result<Option<PersistedSession>> {
     let path = session_path()?;
     match fs::read_to_string(&path) {
         Ok(json) => {
-            let session: PersistedSession =
+            let mut session: PersistedSession =
                 serde_json::from_str(&json).map_err(|e| Error::Storage {
                     reason: format!("decode {}: {e}", path.display()),
                 })?;
+            // Proactively strip a *redundant* clear-text refresh token: once the
+            // encrypted variant exists, the plaintext is dead weight that only
+            // adds disk-read/session-replay risk (a `session.json` synced to a
+            // backup folder). Drop it in memory and re-persist without it. When
+            // only the plaintext exists (a pre-encryption session not yet
+            // unlocked) it can't be re-encrypted without the master key, so it
+            // stays until the first unlock migrates it (see `commands::auth::unlock`).
+            if session.refresh_token.is_some() && session.encrypted_refresh_token.is_some() {
+                session.refresh_token = None;
+                let _ = save_session(&session);
+            }
             Ok(Some(session))
         }
         Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),


### PR DESCRIPTION
Fourth security-review PR — five small, independent, low-regression hardening items.

- **M5** — auto-lock watchdog clears the pending-2FA slot (master key + password hash): drops it when past its TTL every tick (even with auto-lock off) and on idle-lock. An abandoned 2FA prompt no longer leaves that material in memory past the TTL/auto-lock backstop.
- **L4** — data dir → `0700` (blocks a second local user from the encrypted DB + journal/WAL sidecars + session.json regardless of file mode) and `vault.db` created `0600` atomically instead of umask-default + racy chmod.
- **L5** — proactively strip a redundant clear-text refresh token from `session.json` on load once the encrypted variant exists.
- **L6** — `TokenSet` is `ZeroizeOnDrop`: access + refresh tokens (and wrapped key material) wiped on session teardown; non-secret fields skipped.
- **L8** — stop logging decrypted cipher item names to stderr on SSH-agent load failures (still shown in-UI via `SkippedKey`).

## Verification
- `cargo clippy --all-targets -D warnings` ✓ · `cargo fmt --check` ✓ · `cargo test --tests` ✓ (153)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH