### PR TITLE
fix(security): share-body fields (L7) + parse_kdbx cap (L2) + RSA advisory (L3)

### DIFF
--- a/src-tauri/src/commands/import.rs
+++ b/src-tauri/src/commands/import.rs
@@ -50,8 +50,22 @@ pub struct KdbxEntry {
 /// empty `password` rows are dropped: KeePassXC sometimes leaves
 /// empty placeholder entries under the root group and they're never
 /// useful in a Bitwarden vault.
+/// A real KDBX database is well under this. The cap stops a compromised
+/// renderer from forcing a huge native allocation by handing an oversized
+/// buffer to the parser (memory DoS).
+const MAX_KDBX_BYTES: usize = 64 * 1024 * 1024;
+
 #[tauri::command]
 pub fn parse_kdbx(bytes: Vec<u8>, password: String) -> Result<Vec<KdbxEntry>> {
+    if bytes.len() > MAX_KDBX_BYTES {
+        return Err(Error::Storage {
+            reason: format!(
+                "KDBX file too large: {} bytes (max {} MiB)",
+                bytes.len(),
+                MAX_KDBX_BYTES / (1024 * 1024)
+            ),
+        });
+    }
     let key = DatabaseKey::new().with_password(&password);
     let db = Database::parse(&bytes, key).map_err(|e| {
         // The keepass crate distinguishes "wrong password" from

--- a/src-tauri/src/crypto.rs
+++ b/src-tauri/src/crypto.rs
@@ -243,6 +243,13 @@ impl EncString {
     pub fn decrypt_rsa(&self, private_key: &RsaPrivateKey) -> Result<Vec<u8>> {
         match self {
             Self::Rsa2048OaepSha1 { ciphertext } => {
+                // SHA-1 in OAEP is per the Bitwarden spec (fine). The residual
+                // risk is RUSTSEC-2023-0071: the `rsa` crate's decryption is not
+                // constant-time (Marvin timing side-channel), with no fixed 0.9.x
+                // release yet. We reach this only for server-supplied type-4
+                // EncStrings (org key unwrap), over HTTPS, with no attacker-facing
+                // oracle — exposure is low. Tracked/ignored in ci.yml's cargo-audit
+                // step; upgrade the crate as soon as a constant-time release lands.
                 let padding = Oaep::new::<Sha1>();
                 private_key
                     .decrypt(padding, ciphertext)

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -227,6 +227,36 @@ pub struct Cipher {
     pub identity: Option<CipherIdentity>,
     #[serde(default)]
     pub ssh_key: Option<CipherSshKey>,
+    /// Custom fields. `name`/`value` are EncStrings; `type`/`linked_id` are
+    /// plaintext metadata. Modelled so sharing to an org can rewrap them
+    /// instead of silently dropping them (the share PUT has replace semantics).
+    #[serde(default)]
+    pub fields: Option<Vec<CipherField>>,
+    /// Password history entries; `password` is an EncString.
+    #[serde(default)]
+    pub password_history: Option<Vec<CipherPasswordHistory>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CipherField {
+    #[serde(rename = "type", default)]
+    pub kind: Option<u8>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default)]
+    pub linked_id: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CipherPasswordHistory {
+    #[serde(default)]
+    pub last_used_date: Option<String>,
+    #[serde(default)]
+    pub password: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/services/cipher.rs
+++ b/src-tauri/src/services/cipher.rs
@@ -315,6 +315,44 @@ pub fn build_share_cipher_body(
         })
         .transpose()?;
 
+    // Custom fields and password history must be rewrapped and carried across,
+    // or the replace-semantics share PUT silently deletes them for everyone.
+    let fields_json = cipher
+        .fields
+        .as_ref()
+        .map(|fields| -> Result<serde_json::Value> {
+            let arr = fields
+                .iter()
+                .map(|f| -> Result<serde_json::Value> {
+                    Ok(serde_json::json!({
+                        "type": f.kind,
+                        "name": reenc_opt(f.name.as_deref())?,
+                        "value": reenc_opt(f.value.as_deref())?,
+                        "linkedId": f.linked_id,
+                    }))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(serde_json::Value::Array(arr))
+        })
+        .transpose()?;
+
+    let password_history_json = cipher
+        .password_history
+        .as_ref()
+        .map(|hist| -> Result<serde_json::Value> {
+            let arr = hist
+                .iter()
+                .map(|h| -> Result<serde_json::Value> {
+                    Ok(serde_json::json!({
+                        "lastUsedDate": h.last_used_date,
+                        "password": reenc_opt(h.password.as_deref())?,
+                    }))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(serde_json::Value::Array(arr))
+        })
+        .transpose()?;
+
     Ok(serde_json::json!({
         "cipher": {
             "type": cipher.kind as u8,
@@ -328,6 +366,8 @@ pub fn build_share_cipher_body(
             "card": card_json,
             "identity": identity_json,
             "sshKey": ssh_key_json,
+            "fields": fields_json,
+            "passwordHistory": password_history_json,
         },
         "collectionIds": collection_ids,
     }))
@@ -338,8 +378,8 @@ mod tests {
     use super::*;
     use crate::crypto::{decrypt_name, SymmetricKey};
     use crate::models::{
-        CardInput, CipherCreateInput, CipherLogin, CipherLoginUri, CipherType, IdentityInput,
-        LoginInput, SshKeyInput,
+        CardInput, CipherCreateInput, CipherField, CipherLogin, CipherLoginUri,
+        CipherPasswordHistory, CipherType, IdentityInput, LoginInput, SshKeyInput,
     };
 
     fn test_key() -> SymmetricKey {
@@ -377,6 +417,8 @@ mod tests {
             card: None,
             identity: None,
             ssh_key: None,
+            fields: None,
+            password_history: None,
         }
     }
 
@@ -476,6 +518,48 @@ mod tests {
         cipher.key = Some(encrypt_cipher_key(&item, &stranger).unwrap());
 
         assert!(item_key(&cipher, &user).is_none());
+    }
+
+    #[test]
+    fn share_body_rewraps_custom_fields_and_password_history() {
+        // Regression for the silent data loss on share (L7): custom fields and
+        // password history must be rewrapped source -> org key and carried in
+        // the body, not dropped.
+        let user = test_key();
+        let org = other_test_key();
+        let mut cipher = base_cipher(CipherType::Login, &user);
+        cipher.fields = Some(vec![CipherField {
+            kind: Some(1),
+            name: Some(encrypt_string("recovery", &user).unwrap()),
+            value: Some(encrypt_string("code-123", &user).unwrap()),
+            linked_id: None,
+        }]);
+        cipher.password_history = Some(vec![CipherPasswordHistory {
+            last_used_date: Some("2024-01-01T00:00:00Z".into()),
+            password: Some(encrypt_string("old-pass", &user).unwrap()),
+        }]);
+
+        let body =
+            build_share_cipher_body(&cipher, &user, &org, "org-1", &["col-1".into()]).unwrap();
+        let c = &body["cipher"];
+
+        let f = &c["fields"][0];
+        assert_eq!(f["type"], 1);
+        assert_eq!(
+            decrypt_name(f["name"].as_str().unwrap(), &org).unwrap(),
+            "recovery"
+        );
+        assert_eq!(
+            decrypt_name(f["value"].as_str().unwrap(), &org).unwrap(),
+            "code-123"
+        );
+
+        let h = &c["passwordHistory"][0];
+        assert_eq!(h["lastUsedDate"], "2024-01-01T00:00:00Z");
+        assert_eq!(
+            decrypt_name(h["password"].as_str().unwrap(), &org).unwrap(),
+            "old-pass"
+        );
     }
 
     #[test]

--- a/src-tauri/src/services/vault.rs
+++ b/src-tauri/src/services/vault.rs
@@ -256,6 +256,8 @@ mod tests {
             card: None,
             identity: None,
             ssh_key: None,
+            fields: None,
+            password_history: None,
         }
     }
 
@@ -281,6 +283,8 @@ mod tests {
             card: None,
             identity: None,
             ssh_key: None,
+            fields: None,
+            password_history: None,
         }
     }
 


### PR DESCRIPTION
Security-review PR — correctness + limits.

- **L7** — sharing to an org silently dropped `fields` (custom fields: recovery codes, secondary passwords, API tokens) and `passwordHistory`, because they weren't modelled on `Cipher` and the share `PUT` has replace semantics. Now modelled and rewrapped source→org key like every other subfield; test covers a round-trip decrypting under the org key. (Attachments still out of scope — need a migrate-or-refuse flow.)
- **L2** — `parse_kdbx` rejects payloads > 64 MiB before parsing (unbounded-allocation DoS).
- **L3** — documents the residual RSA risk (RUSTSEC-2023-0071 / Marvin) at the decrypt site; low exposure, tracked in ci.yml cargo-audit.

## Verification
- `cargo clippy --all-targets -D warnings` ✓ · `cargo fmt --check` ✓ · `cargo test --tests` ✓ (154; new: share fields/passwordHistory round-trip)

Remaining from the review: **M4** (TOTP-in-Rust) + **L1** (metadata-only `get_cipher`) — the secrets-to-JS refactor, coming as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH