### PR TITLE
fix(security): SSH private key out of the WebView, reveal-on-demand (L1a)

### DIFF
--- a/src-tauri/src/commands/cipher.rs
+++ b/src-tauri/src/commands/cipher.rs
@@ -76,7 +76,8 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
     });
 
     let ssh_key = cipher.ssh_key.as_ref().map(|s| SshKeyDetail {
-        private_key: s.private_key.as_deref().and_then(decrypt_opt),
+        // Presence only — the private key stays in Rust (see `reveal_field`).
+        has_private_key: s.private_key.as_deref().is_some_and(|k| !k.is_empty()),
         public_key: s.public_key.as_deref().and_then(decrypt_opt),
         key_fingerprint: s.key_fingerprint.as_deref().and_then(decrypt_opt),
     });
@@ -96,6 +97,54 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
         identity,
         ssh_key,
     })
+}
+
+/// Decrypt a single secret field of a cipher on demand, by id + field name, so
+/// full plaintext secrets are not eagerly returned by `get_cipher` and left in
+/// long-lived JS reactive state. `field` is one of: "password", "cardNumber",
+/// "cardCode", "ssn", "sshPrivateKey". Returns None when the field is
+/// absent/empty.
+#[tauri::command]
+pub fn reveal_field(
+    state: State<'_, AppState>,
+    id: String,
+    field: String,
+) -> Result<Option<String>> {
+    crate::state::mark_activity(&state);
+    let guard = state.session.lock();
+    let session = guard.as_ref().ok_or(Error::NotAuthenticated)?;
+    let vault = session.vault.as_ref().ok_or_else(|| Error::Storage {
+        reason: "no vault synced yet — synchronise first".into(),
+    })?;
+    let cipher = vault
+        .ciphers
+        .iter()
+        .find(|c| c.id == id)
+        .ok_or_else(|| Error::Storage {
+            reason: format!("cipher not found: {id}"),
+        })?;
+    let owner = owning_key(cipher, &session.user_key, &session.org_keys);
+    let item = item_key(cipher, owner);
+    let key = item.as_ref().unwrap_or(owner);
+
+    let enc: Option<&str> = match field.as_str() {
+        "password" => cipher.login.as_ref().and_then(|l| l.password.as_deref()),
+        "cardNumber" => cipher.card.as_ref().and_then(|c| c.number.as_deref()),
+        "cardCode" => cipher.card.as_ref().and_then(|c| c.code.as_deref()),
+        "ssn" => cipher.identity.as_ref().and_then(|i| i.ssn.as_deref()),
+        "sshPrivateKey" => cipher
+            .ssh_key
+            .as_ref()
+            .and_then(|s| s.private_key.as_deref()),
+        other => {
+            return Err(Error::Storage {
+                reason: format!("unknown reveal field: {other}"),
+            })
+        }
+    };
+    Ok(enc
+        .and_then(|e| decrypt_name(e, key).ok())
+        .filter(|s| !s.is_empty()))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -127,6 +127,7 @@ pub fn run() {
             commands::vault::delete_folder,
             commands::vault::rename_folder,
             commands::cipher::get_cipher,
+            commands::cipher::reveal_field,
             commands::cipher::create_login_cipher,
             commands::cipher::update_login_cipher,
             commands::cipher::create_cipher,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -382,7 +382,9 @@ pub struct IdentityDetail {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SshKeyDetail {
-    pub private_key: Option<String>,
+    /// The private key never crosses to JS (it's the worst leak — reused across
+    /// servers). Fetch it on demand with `reveal_field(id, "sshPrivateKey")`.
+    pub has_private_key: bool,
     pub public_key: Option<String>,
     pub key_fingerprint: Option<String>,
 }

--- a/src/lib/CipherDetail.svelte
+++ b/src/lib/CipherDetail.svelte
@@ -2,6 +2,7 @@
   import * as m from "$lib/paraglide/messages";
   import Icon from "./Icon.svelte";
   import TotpField from "./TotpField.svelte";
+  import { api } from "./api";
   import { cipherTypeLabel, mask } from "./format";
   import type { CipherDetail, CipherSummary, OrganizationSummary } from "./types";
 
@@ -35,6 +36,25 @@
   let showSsn = $state(false);
   let showSshPrivate = $state(false);
 
+  // Secret fields are no longer in `detail`; they're fetched on demand and held
+  // only while revealed. `revealed[field]` caches the fetched value for the
+  // currently open item; wiped whenever the item changes.
+  let revealed = $state<Record<string, string>>({});
+
+  async function revealValue(field: string): Promise<string> {
+    if (revealed[field] === undefined) {
+      revealed = { ...revealed, [field]: (await api.revealField(detail.id, field)) ?? "" };
+    }
+    return revealed[field];
+  }
+
+  /** Copy a secret field, fetching it first if needed (kept out of long-lived
+      state — only touched transiently for the copy). */
+  async function copyField(field: string, label: string) {
+    const value = await revealValue(field);
+    if (value) await onCopy(value, label);
+  }
+
   $effect(() => {
     void detail.id;
     showPassword = false;
@@ -42,6 +62,7 @@
     showCardCode = false;
     showSsn = false;
     showSshPrivate = false;
+    revealed = {};
   });
 
   const isDeleted = $derived(summaryEntry?.deletedDate ?? null);
@@ -345,15 +366,38 @@
           </dd>
         </div>
       {/if}
-      {#if detail.sshKey.privateKey}
-        {@render secretField(
-          m.detail_field_private_key(),
-          detail.sshKey.privateKey,
-          showSshPrivate,
-          () => (showSshPrivate = !showSshPrivate),
-          "clé privée",
-          { masked: m.detail_field_private_key_hidden(), renderShown: "ssh" }
-        )}
+      {#if detail.sshKey.hasPrivateKey}
+        <div class="detail-field" role="group">
+          <dt>{m.detail_field_private_key()}</dt>
+          <dd>
+            {#if showSshPrivate}
+              <code class="value ssh-key">{revealed["sshPrivateKey"] ?? ""}</code>
+            {:else}
+              <code class="value">{m.detail_field_private_key_hidden()}</code>
+            {/if}
+            <button
+              type="button"
+              class="icon-btn"
+              title={showSshPrivate ? m.action_hide_value() : m.action_show()}
+              aria-label={showSshPrivate ? m.action_hide_value() : m.action_show()}
+              onclick={async () => {
+                if (!showSshPrivate) await revealValue("sshPrivateKey");
+                showSshPrivate = !showSshPrivate;
+              }}
+            >
+              <Icon name={showSshPrivate ? "eye-off" : "eye"} size={14} />
+            </button>
+            <button
+              type="button"
+              class="icon-btn primary"
+              title={m.action_copy()}
+              aria-label={m.action_copy()}
+              onclick={() => copyField("sshPrivateKey", "clé privée")}
+            >
+              <Icon name="copy" size={14} />
+            </button>
+          </dd>
+        </div>
       {/if}
     </section>
   {/if}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -133,6 +133,12 @@ export const api = {
 
   getCipher: (id: string) => invoke<CipherDetail>("get_cipher", { id }),
 
+  /** Decrypt a single secret field on demand (kept out of get_cipher / JS
+      reactive state). field: password | cardNumber | cardCode | ssn |
+      sshPrivateKey. */
+  revealField: (id: string, field: string) =>
+    invoke<string | null>("reveal_field", { id, field }),
+
   createCipher: (input: EditorPayload) =>
     invoke<string>("create_cipher", { input: payloadToRust(input) }),
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,7 +107,9 @@ export type IdentityDetail = {
 };
 
 export type SshKeyDetail = {
-  privateKey: string | null;
+  /** The private key stays in Rust; fetch on demand with
+      `api.revealField(id, "sshPrivateKey")`. */
+  hasPrivateKey: boolean;
   publicKey: string | null;
   keyFingerprint: string | null;
 };

--- a/src/lib/vault.svelte.ts
+++ b/src/lib/vault.svelte.ts
@@ -357,7 +357,18 @@ export class VaultController {
     this.editorOpen = true;
   }
 
-  openEditEditor() {
+  async openEditEditor() {
+    if (!this.detail) return;
+    // The SSH private key is no longer in `detail`; fetch it so the editor can
+    // keep it (otherwise saving would wipe the key).
+    let sshPrivateKey = "";
+    if (this.detail.sshKey?.hasPrivateKey) {
+      try {
+        sshPrivateKey = (await api.revealField(this.detail.id, "sshPrivateKey")) ?? "";
+      } catch (e) {
+        this.error = formatError(e);
+      }
+    }
     if (!this.detail) return;
     const currentCipher = this.summary?.ciphers.find((c) => c.id === this.detail!.id);
     const kind = (this.detail.kind as 1 | 2 | 3 | 4 | 5) ?? 1;
@@ -402,7 +413,7 @@ export class VaultController {
         licenseNumber: this.detail.identity?.licenseNumber ?? "",
       },
       sshKey: {
-        privateKey: this.detail.sshKey?.privateKey ?? "",
+        privateKey: sshPrivateKey,
         publicKey: this.detail.sshKey?.publicKey ?? "",
         keyFingerprint: this.detail.sshKey?.keyFingerprint ?? "",
       },


### PR DESCRIPTION
**L1a** (first half of the metadata-only `get_cipher` work). `get_cipher` returned the full decrypted OpenSSH private-key PEM, held in long-lived JS state — the worst secrets-to-JS leak per the review (private keys are reused across servers).

- `SshKeyDetail` → `has_private_key` (no PEM); public key + fingerprint still returned for display.
- New generic `reveal_field(id, field)` command (arms: password / cardNumber / cardCode / ssn / sshPrivateKey) — L1a wires only `sshPrivateKey`.
- Detail view: reveal fetches on click; copy fetch-then-copies (transient only).
- Editor fetches the key lazily so saving doesn't wipe it.

Merges cleanly alongside M4 (#152) — different struct lines. **L1b** (password/card/ssn metadata-only + copy-in-Rust) stacks on this.

## Verification
- `cargo clippy -D warnings` ✓ · `cargo fmt --check` ✓ · `cargo test --tests` ✓ (153) · `pnpm check` ✓ · `pnpm test` ✓ (126)
- Device confirmation: SSH private key reveal/copy in detail + edit preserves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtZbSWv6HgyhSxuMJ3H4HH