### PR TITLE
fix(security): password/card/CVV/SSN out of the WebView, reveal-on-demand (L1b)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 
 [[package]]
 name = "clavix"
-version = "0.2.9"
+version = "0.4.0"
 dependencies = [
  "aes 0.8.4",
  "argon2",

--- a/src-tauri/src/commands/cipher.rs
+++ b/src-tauri/src/commands/cipher.rs
@@ -42,7 +42,8 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
             .iter()
             .filter_map(|u| u.uri.as_deref().and_then(decrypt_opt))
             .collect(),
-        totp: l.totp.as_deref().and_then(decrypt_opt),
+        // Presence only — the seed stays in Rust (see `totp_code`).
+        has_totp: l.totp.as_deref().is_some_and(|t| !t.is_empty()),
     });
 
     let card = cipher.card.as_ref().map(|c| CardDetail {
@@ -145,6 +146,53 @@ pub fn reveal_field(
     Ok(enc
         .and_then(|e| decrypt_name(e, key).ok())
         .filter(|s| !s.is_empty()))
+}
+
+/// Decrypt a login item's TOTP secret (otpauth URI or bare base32) by id,
+/// under its item/owning key. Kept in Rust so the seed never reaches JS.
+fn decrypt_totp_secret(state: &AppState, id: &str) -> Result<Option<String>> {
+    let guard = state.session.lock();
+    let session = guard.as_ref().ok_or(Error::NotAuthenticated)?;
+    let vault = session.vault.as_ref().ok_or_else(|| Error::Storage {
+        reason: "no vault synced yet — synchronise first".into(),
+    })?;
+    let cipher = vault
+        .ciphers
+        .iter()
+        .find(|c| c.id == id)
+        .ok_or_else(|| Error::Storage {
+            reason: format!("cipher not found: {id}"),
+        })?;
+    let owner = owning_key(cipher, &session.user_key, &session.org_keys);
+    let item = item_key(cipher, owner);
+    let key = item.as_ref().unwrap_or(owner);
+    Ok(cipher
+        .login
+        .as_ref()
+        .and_then(|l| l.totp.as_deref())
+        .and_then(|t| decrypt_name(t, key).ok())
+        .filter(|s| !s.is_empty()))
+}
+
+/// Current TOTP code + seconds remaining for a login item. Computed in Rust so
+/// the shared secret stays out of the WebView (a leaked seed = permanent 2FA
+/// bypass). The renderer polls this once a second for the live field.
+#[tauri::command]
+pub fn totp_code(state: State<'_, AppState>, id: String) -> Result<crate::totp::TotpCode> {
+    crate::state::mark_activity(&state);
+    let secret = decrypt_totp_secret(&state, &id)?.ok_or_else(|| Error::Storage {
+        reason: "item has no TOTP secret".into(),
+    })?;
+    crate::totp::code_now(&secret)
+}
+
+/// The raw TOTP secret, only for the editor (to edit it) and export (to write
+/// it out) — the two legitimate places that need the seed itself rather than a
+/// code. Everything else uses `totp_code`.
+#[tauri::command]
+pub fn reveal_login_totp(state: State<'_, AppState>, id: String) -> Result<Option<String>> {
+    crate::state::mark_activity(&state);
+    decrypt_totp_secret(&state, &id)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/cipher.rs
+++ b/src-tauri/src/commands/cipher.rs
@@ -42,7 +42,8 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
             .iter()
             .filter_map(|u| u.uri.as_deref().and_then(decrypt_opt))
             .collect(),
-        totp: l.totp.as_deref().and_then(decrypt_opt),
+        // Presence only — the seed stays in Rust (see `totp_code`).
+        has_totp: l.totp.as_deref().is_some_and(|t| !t.is_empty()),
     });
 
     let card = cipher.card.as_ref().map(|c| CardDetail {
@@ -96,6 +97,53 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
         identity,
         ssh_key,
     })
+}
+
+/// Decrypt a login item's TOTP secret (otpauth URI or bare base32) by id,
+/// under its item/owning key. Kept in Rust so the seed never reaches JS.
+fn decrypt_totp_secret(state: &AppState, id: &str) -> Result<Option<String>> {
+    let guard = state.session.lock();
+    let session = guard.as_ref().ok_or(Error::NotAuthenticated)?;
+    let vault = session.vault.as_ref().ok_or_else(|| Error::Storage {
+        reason: "no vault synced yet — synchronise first".into(),
+    })?;
+    let cipher = vault
+        .ciphers
+        .iter()
+        .find(|c| c.id == id)
+        .ok_or_else(|| Error::Storage {
+            reason: format!("cipher not found: {id}"),
+        })?;
+    let owner = owning_key(cipher, &session.user_key, &session.org_keys);
+    let item = item_key(cipher, owner);
+    let key = item.as_ref().unwrap_or(owner);
+    Ok(cipher
+        .login
+        .as_ref()
+        .and_then(|l| l.totp.as_deref())
+        .and_then(|t| decrypt_name(t, key).ok())
+        .filter(|s| !s.is_empty()))
+}
+
+/// Current TOTP code + seconds remaining for a login item. Computed in Rust so
+/// the shared secret stays out of the WebView (a leaked seed = permanent 2FA
+/// bypass). The renderer polls this once a second for the live field.
+#[tauri::command]
+pub fn totp_code(state: State<'_, AppState>, id: String) -> Result<crate::totp::TotpCode> {
+    crate::state::mark_activity(&state);
+    let secret = decrypt_totp_secret(&state, &id)?.ok_or_else(|| Error::Storage {
+        reason: "item has no TOTP secret".into(),
+    })?;
+    crate::totp::code_now(&secret)
+}
+
+/// The raw TOTP secret, only for the editor (to edit it) and export (to write
+/// it out) — the two legitimate places that need the seed itself rather than a
+/// code. Everything else uses `totp_code`.
+#[tauri::command]
+pub fn reveal_login_totp(state: State<'_, AppState>, id: String) -> Result<Option<String>> {
+    crate::state::mark_activity(&state);
+    decrypt_totp_secret(&state, &id)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/cipher.rs
+++ b/src-tauri/src/commands/cipher.rs
@@ -32,9 +32,14 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
 
     let decrypt_opt = |s: &str| -> Option<String> { decrypt_name(s, key).ok() };
 
+    // A field is "present" when it decrypts to a non-empty value; secrets are
+    // reported as booleans only and fetched on demand via `reveal_field`.
+    let present =
+        |s: Option<&str>| -> bool { s.and_then(decrypt_opt).is_some_and(|v| !v.is_empty()) };
+
     let login = cipher.login.as_ref().map(|l| LoginDetail {
         username: l.username.as_deref().and_then(decrypt_opt),
-        password: l.password.as_deref().and_then(decrypt_opt),
+        has_password: present(l.password.as_deref()),
         uris: l
             .uris
             .as_deref()
@@ -49,10 +54,10 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
     let card = cipher.card.as_ref().map(|c| CardDetail {
         cardholder_name: c.cardholder_name.as_deref().and_then(decrypt_opt),
         brand: c.brand.as_deref().and_then(decrypt_opt),
-        number: c.number.as_deref().and_then(decrypt_opt),
+        has_number: present(c.number.as_deref()),
         exp_month: c.exp_month.as_deref().and_then(decrypt_opt),
         exp_year: c.exp_year.as_deref().and_then(decrypt_opt),
-        code: c.code.as_deref().and_then(decrypt_opt),
+        has_code: present(c.code.as_deref()),
     });
 
     let identity = cipher.identity.as_ref().map(|i| IdentityDetail {
@@ -70,7 +75,7 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
         company: i.company.as_deref().and_then(decrypt_opt),
         email: i.email.as_deref().and_then(decrypt_opt),
         phone: i.phone.as_deref().and_then(decrypt_opt),
-        ssn: i.ssn.as_deref().and_then(decrypt_opt),
+        has_ssn: present(i.ssn.as_deref()),
         username: i.username.as_deref().and_then(decrypt_opt),
         passport_number: i.passport_number.as_deref().and_then(decrypt_opt),
         license_number: i.license_number.as_deref().and_then(decrypt_opt),

--- a/src-tauri/src/commands/cipher.rs
+++ b/src-tauri/src/commands/cipher.rs
@@ -76,7 +76,8 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
     });
 
     let ssh_key = cipher.ssh_key.as_ref().map(|s| SshKeyDetail {
-        private_key: s.private_key.as_deref().and_then(decrypt_opt),
+        // Presence only — the private key stays in Rust (see `reveal_field`).
+        has_private_key: s.private_key.as_deref().is_some_and(|k| !k.is_empty()),
         public_key: s.public_key.as_deref().and_then(decrypt_opt),
         key_fingerprint: s.key_fingerprint.as_deref().and_then(decrypt_opt),
     });
@@ -96,6 +97,54 @@ pub fn get_cipher(state: State<'_, AppState>, id: String) -> Result<CipherDetail
         identity,
         ssh_key,
     })
+}
+
+/// Decrypt a single secret field of a cipher on demand, by id + field name, so
+/// full plaintext secrets are not eagerly returned by `get_cipher` and left in
+/// long-lived JS reactive state. `field` is one of: "password", "cardNumber",
+/// "cardCode", "ssn", "sshPrivateKey". Returns None when the field is
+/// absent/empty.
+#[tauri::command]
+pub fn reveal_field(
+    state: State<'_, AppState>,
+    id: String,
+    field: String,
+) -> Result<Option<String>> {
+    crate::state::mark_activity(&state);
+    let guard = state.session.lock();
+    let session = guard.as_ref().ok_or(Error::NotAuthenticated)?;
+    let vault = session.vault.as_ref().ok_or_else(|| Error::Storage {
+        reason: "no vault synced yet — synchronise first".into(),
+    })?;
+    let cipher = vault
+        .ciphers
+        .iter()
+        .find(|c| c.id == id)
+        .ok_or_else(|| Error::Storage {
+            reason: format!("cipher not found: {id}"),
+        })?;
+    let owner = owning_key(cipher, &session.user_key, &session.org_keys);
+    let item = item_key(cipher, owner);
+    let key = item.as_ref().unwrap_or(owner);
+
+    let enc: Option<&str> = match field.as_str() {
+        "password" => cipher.login.as_ref().and_then(|l| l.password.as_deref()),
+        "cardNumber" => cipher.card.as_ref().and_then(|c| c.number.as_deref()),
+        "cardCode" => cipher.card.as_ref().and_then(|c| c.code.as_deref()),
+        "ssn" => cipher.identity.as_ref().and_then(|i| i.ssn.as_deref()),
+        "sshPrivateKey" => cipher
+            .ssh_key
+            .as_ref()
+            .and_then(|s| s.private_key.as_deref()),
+        other => {
+            return Err(Error::Storage {
+                reason: format!("unknown reveal field: {other}"),
+            })
+        }
+    };
+    Ok(enc
+        .and_then(|e| decrypt_name(e, key).ok())
+        .filter(|s| !s.is_empty()))
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -127,6 +127,7 @@ pub fn run() {
             commands::vault::delete_folder,
             commands::vault::rename_folder,
             commands::cipher::get_cipher,
+            commands::cipher::reveal_field,
             commands::cipher::create_login_cipher,
             commands::cipher::update_login_cipher,
             commands::cipher::create_cipher,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod state;
 // spec — disk-artifact assertions, restart-simulation — need direct
 // access to load_session / save_session / clear_session.
 pub mod store;
+mod totp;
 mod webauthn;
 mod yubikey_unlock;
 
@@ -128,6 +129,8 @@ pub fn run() {
             commands::vault::rename_folder,
             commands::cipher::get_cipher,
             commands::cipher::reveal_field,
+            commands::cipher::totp_code,
+            commands::cipher::reveal_login_totp,
             commands::cipher::create_login_cipher,
             commands::cipher::update_login_cipher,
             commands::cipher::create_cipher,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ pub mod state;
 // spec — disk-artifact assertions, restart-simulation — need direct
 // access to load_session / save_session / clear_session.
 pub mod store;
+mod totp;
 mod webauthn;
 mod yubikey_unlock;
 
@@ -127,6 +128,8 @@ pub fn run() {
             commands::vault::delete_folder,
             commands::vault::rename_folder,
             commands::cipher::get_cipher,
+            commands::cipher::totp_code,
+            commands::cipher::reveal_login_totp,
             commands::cipher::create_login_cipher,
             commands::cipher::update_login_cipher,
             commands::cipher::create_cipher,

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -342,7 +342,13 @@ pub struct LoginDetail {
     pub username: Option<String>,
     pub password: Option<String>,
     pub uris: Vec<String>,
-    pub totp: Option<String>,
+    /// Whether the item carries a TOTP secret. The secret itself is NOT sent to
+    /// the WebView (it would let a compromised renderer mint valid codes
+    /// forever — a permanent 2FA bypass). The renderer asks
+    /// `commands::cipher::totp_code` for the current code, and
+    /// `reveal_login_totp` for the raw secret only when the editor/export needs
+    /// it.
+    pub has_totp: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -382,7 +382,9 @@ pub struct IdentityDetail {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SshKeyDetail {
-    pub private_key: Option<String>,
+    /// The private key never crosses to JS (it's the worst leak — reused across
+    /// servers). Fetch it on demand with `reveal_field(id, "sshPrivateKey")`.
+    pub has_private_key: bool,
     pub public_key: Option<String>,
     pub key_fingerprint: Option<String>,
 }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -340,7 +340,9 @@ pub struct CipherDetail {
 #[serde(rename_all = "camelCase")]
 pub struct LoginDetail {
     pub username: Option<String>,
-    pub password: Option<String>,
+    /// Presence only — the password is fetched on demand via
+    /// `reveal_field(id, "password")` so it doesn't sit in long-lived JS state.
+    pub has_password: bool,
     pub uris: Vec<String>,
     /// Whether the item carries a TOTP secret. The secret itself is NOT sent to
     /// the WebView (it would let a compromised renderer mint valid codes
@@ -356,10 +358,12 @@ pub struct LoginDetail {
 pub struct CardDetail {
     pub cardholder_name: Option<String>,
     pub brand: Option<String>,
-    pub number: Option<String>,
+    /// Card number + CVV are fetched on demand (`reveal_field(id, "cardNumber"
+    /// | "cardCode")`); only their presence is sent eagerly.
+    pub has_number: bool,
     pub exp_month: Option<String>,
     pub exp_year: Option<String>,
-    pub code: Option<String>,
+    pub has_code: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -379,7 +383,8 @@ pub struct IdentityDetail {
     pub company: Option<String>,
     pub email: Option<String>,
     pub phone: Option<String>,
-    pub ssn: Option<String>,
+    /// SSN is fetched on demand via `reveal_field(id, "ssn")`.
+    pub has_ssn: bool,
     pub username: Option<String>,
     pub passport_number: Option<String>,
     pub license_number: Option<String>,

--- a/src-tauri/src/totp.rs
+++ b/src-tauri/src/totp.rs
@@ -1,0 +1,221 @@
+//! TOTP (RFC 6238) computed in Rust so the shared secret / otpauth URI never
+//! crosses into the WebView. `get_cipher` no longer returns the seed; the
+//! renderer asks `commands::cipher::totp_code` for the current code only, and
+//! the editor asks `reveal_login_totp` when it needs the raw secret to edit.
+//!
+//! Mirrors the previous JS implementation (`src/lib/totp.ts`) — same base32
+//! decode, otpauth parsing, clamping, and HOTP truncation — verified against
+//! the RFC 6238 Appendix B vectors below.
+
+use hmac::{Hmac, Mac};
+use sha1::Sha1;
+use sha2::{Sha256, Sha512};
+
+use crate::error::{Error, Result};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Algorithm {
+    Sha1,
+    Sha256,
+    Sha512,
+}
+
+struct TotpConfig {
+    secret: Vec<u8>,
+    period: u64,
+    digits: u32,
+    algorithm: Algorithm,
+}
+
+/// The current code plus how many seconds until it rolls over. Serialised to
+/// the renderer for the live-updating TOTP field.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TotpCode {
+    pub code: String,
+    pub seconds_remaining: u64,
+}
+
+const BASE32_ALPHABET: &[u8; 32] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+fn decode_base32(input: &str) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    let mut bits: u32 = 0;
+    let mut value: u32 = 0;
+    for ch in input
+        .chars()
+        .filter(|c| !c.is_whitespace() && *c != '=')
+        .map(|c| c.to_ascii_uppercase())
+    {
+        let idx = BASE32_ALPHABET
+            .iter()
+            .position(|&b| b as char == ch)
+            .ok_or_else(|| Error::Crypto {
+                reason: format!("invalid base32 char: {ch}"),
+            })?;
+        value = (value << 5) | idx as u32;
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            bytes.push(((value >> bits) & 0xff) as u8);
+        }
+    }
+    Ok(bytes)
+}
+
+/// Clamp an untrusted numeric parameter to a sane range, falling back when the
+/// value is missing or out of range — prevents an aberrant `digits` from a
+/// hostile otpauth URI triggering a huge allocation.
+fn clamp_param(raw: Option<&str>, min: u64, max: u64, fallback: u64) -> u64 {
+    match raw.and_then(|s| s.parse::<f64>().ok()) {
+        Some(n) if n.is_finite() && n > 0.0 => (n.trunc() as u64).clamp(min, max),
+        _ => fallback,
+    }
+}
+
+fn parse_totp(source: &str) -> Result<TotpConfig> {
+    let trimmed = source.trim();
+    if trimmed.to_ascii_lowercase().starts_with("otpauth://") {
+        let url = url::Url::parse(trimmed).map_err(|e| Error::Crypto {
+            reason: format!("otpauth parse: {e}"),
+        })?;
+        let params: std::collections::HashMap<_, _> = url.query_pairs().into_owned().collect();
+        let secret_raw = params.get("secret").ok_or_else(|| Error::Crypto {
+            reason: "otpauth URI missing secret".into(),
+        })?;
+        let algorithm = match params
+            .get("algorithm")
+            .map(|s| s.to_ascii_uppercase())
+            .as_deref()
+        {
+            Some("SHA256") | Some("SHA-256") => Algorithm::Sha256,
+            Some("SHA512") | Some("SHA-512") => Algorithm::Sha512,
+            _ => Algorithm::Sha1,
+        };
+        Ok(TotpConfig {
+            secret: decode_base32(secret_raw)?,
+            period: clamp_param(params.get("period").map(String::as_str), 1, 3600, 30),
+            digits: clamp_param(params.get("digits").map(String::as_str), 4, 10, 6) as u32,
+            algorithm,
+        })
+    } else {
+        Ok(TotpConfig {
+            secret: decode_base32(trimmed)?,
+            period: 30,
+            digits: 6,
+            algorithm: Algorithm::Sha1,
+        })
+    }
+}
+
+fn hmac_sign(algorithm: Algorithm, key: &[u8], msg: &[u8]) -> Result<Vec<u8>> {
+    fn finalize<M: Mac>(mut mac: M, msg: &[u8]) -> Vec<u8> {
+        mac.update(msg);
+        mac.finalize().into_bytes().to_vec()
+    }
+    fn key_err(e: hmac::digest::InvalidLength) -> Error {
+        Error::Crypto {
+            reason: format!("HMAC key: {e}"),
+        }
+    }
+    Ok(match algorithm {
+        Algorithm::Sha1 => finalize(Hmac::<Sha1>::new_from_slice(key).map_err(key_err)?, msg),
+        Algorithm::Sha256 => finalize(Hmac::<Sha256>::new_from_slice(key).map_err(key_err)?, msg),
+        Algorithm::Sha512 => finalize(Hmac::<Sha512>::new_from_slice(key).map_err(key_err)?, msg),
+    })
+}
+
+fn generate(config: &TotpConfig, now_seconds: u64) -> Result<String> {
+    let counter = now_seconds / config.period;
+    let sig = hmac_sign(config.algorithm, &config.secret, &counter.to_be_bytes())?;
+    let offset = (sig[sig.len() - 1] & 0x0f) as usize;
+    let binary = ((u32::from(sig[offset]) & 0x7f) << 24)
+        | (u32::from(sig[offset + 1]) << 16)
+        | (u32::from(sig[offset + 2]) << 8)
+        | u32::from(sig[offset + 3]);
+    let modulo = 10u32.pow(config.digits);
+    let code = binary % modulo;
+    Ok(format!(
+        "{code:0width$}",
+        code = code,
+        width = config.digits as usize
+    ))
+}
+
+/// Parse `source` (bare base32 secret or otpauth URI) and return the code valid
+/// at `now_seconds` plus the seconds remaining in the current window.
+pub fn code_at(source: &str, now_seconds: u64) -> Result<TotpCode> {
+    let config = parse_totp(source)?;
+    let code = generate(&config, now_seconds)?;
+    let seconds_remaining = config.period - (now_seconds % config.period);
+    Ok(TotpCode {
+        code,
+        seconds_remaining,
+    })
+}
+
+/// The code valid right now.
+pub fn code_now(source: &str) -> Result<TotpCode> {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(|e| Error::Crypto {
+            reason: format!("system clock before epoch: {e}"),
+        })?
+        .as_secs();
+    code_at(source, now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // RFC 6238 Appendix B seeds (ASCII), one per hash size, as bare base32.
+    // "12345678901234567890" -> base32:
+    const SEED_SHA1: &str = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ";
+    // 32-byte and 64-byte seeds via otpauth URIs below.
+
+    #[test]
+    fn rfc6238_sha1_vectors() {
+        // 8-digit codes from RFC 6238 Appendix B (SHA-1 seed).
+        let uri = format!("otpauth://totp/x?secret={SEED_SHA1}&digits=8");
+        assert_eq!(code_at(&uri, 59).unwrap().code, "94287082");
+        assert_eq!(code_at(&uri, 1111111109).unwrap().code, "07081804");
+        assert_eq!(code_at(&uri, 1234567890).unwrap().code, "89005924");
+        assert_eq!(code_at(&uri, 2000000000).unwrap().code, "69279037");
+    }
+
+    #[test]
+    fn rfc6238_sha256_and_sha512_vectors() {
+        // 12345678901234567890123456789012 (32 bytes) base32:
+        let sha256_secret = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZA";
+        let uri = format!("otpauth://totp/x?secret={sha256_secret}&digits=8&algorithm=SHA256");
+        assert_eq!(code_at(&uri, 59).unwrap().code, "46119246");
+
+        // 1234567890123456789012345678901234567890123456789012345678901234 (64) base32:
+        let sha512_secret =
+            "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQGEZDGNA";
+        let uri = format!("otpauth://totp/x?secret={sha512_secret}&digits=8&algorithm=SHA512");
+        assert_eq!(code_at(&uri, 59).unwrap().code, "90693936");
+    }
+
+    #[test]
+    fn bare_secret_defaults_to_6_digits_sha1() {
+        // Low 6 digits of the 8-digit "94287082" at t=59.
+        let c = code_at(SEED_SHA1, 59).unwrap();
+        assert_eq!(c.code, "287082");
+        assert_eq!(c.code.len(), 6);
+    }
+
+    #[test]
+    fn seconds_remaining_counts_down_in_the_window() {
+        assert_eq!(code_at(SEED_SHA1, 0).unwrap().seconds_remaining, 30);
+        assert_eq!(code_at(SEED_SHA1, 1).unwrap().seconds_remaining, 29);
+        assert_eq!(code_at(SEED_SHA1, 29).unwrap().seconds_remaining, 1);
+        assert_eq!(code_at(SEED_SHA1, 30).unwrap().seconds_remaining, 30);
+    }
+
+    #[test]
+    fn rejects_invalid_base32() {
+        assert!(code_at("not base32!!!", 0).is_err());
+    }
+}

--- a/src/lib/CipherDetail.svelte
+++ b/src/lib/CipherDetail.svelte
@@ -2,6 +2,7 @@
   import * as m from "$lib/paraglide/messages";
   import Icon from "./Icon.svelte";
   import TotpField from "./TotpField.svelte";
+  import { api } from "./api";
   import { cipherTypeLabel, mask } from "./format";
   import type { CipherDetail, CipherSummary, OrganizationSummary } from "./types";
 
@@ -35,6 +36,25 @@
   let showSsn = $state(false);
   let showSshPrivate = $state(false);
 
+  // Secret fields are no longer in `detail`; they're fetched on demand and held
+  // only while revealed. `revealed[field]` caches the fetched value for the
+  // currently open item; wiped whenever the item changes.
+  let revealed = $state<Record<string, string>>({});
+
+  async function revealValue(field: string): Promise<string> {
+    if (revealed[field] === undefined) {
+      revealed = { ...revealed, [field]: (await api.revealField(detail.id, field)) ?? "" };
+    }
+    return revealed[field];
+  }
+
+  /** Copy a secret field, fetching it first if needed (kept out of long-lived
+      state — only touched transiently for the copy). */
+  async function copyField(field: string, label: string) {
+    const value = await revealValue(field);
+    if (value) await onCopy(value, label);
+  }
+
   $effect(() => {
     void detail.id;
     showPassword = false;
@@ -42,6 +62,7 @@
     showCardCode = false;
     showSsn = false;
     showSshPrivate = false;
+    revealed = {};
   });
 
   const isDeleted = $derived(summaryEntry?.deletedDate ?? null);
@@ -345,15 +366,38 @@
           </dd>
         </div>
       {/if}
-      {#if detail.sshKey.privateKey}
-        {@render secretField(
-          m.detail_field_private_key(),
-          detail.sshKey.privateKey,
-          showSshPrivate,
-          () => (showSshPrivate = !showSshPrivate),
-          "clé privée",
-          { masked: m.detail_field_private_key_hidden(), renderShown: "ssh" }
-        )}
+      {#if detail.sshKey.hasPrivateKey}
+        <div class="detail-field" role="group">
+          <dt>{m.detail_field_private_key()}</dt>
+          <dd>
+            {#if showSshPrivate}
+              <code class="value ssh-key">{revealed["sshPrivateKey"] ?? ""}</code>
+            {:else}
+              <code class="value">{m.detail_field_private_key_hidden()}</code>
+            {/if}
+            <button
+              type="button"
+              class="icon-btn"
+              title={showSshPrivate ? m.action_hide_value() : m.action_show()}
+              aria-label={showSshPrivate ? m.action_hide_value() : m.action_show()}
+              onclick={async () => {
+                if (!showSshPrivate) await revealValue("sshPrivateKey");
+                showSshPrivate = !showSshPrivate;
+              }}
+            >
+              <Icon name={showSshPrivate ? "eye-off" : "eye"} size={14} />
+            </button>
+            <button
+              type="button"
+              class="icon-btn primary"
+              title={m.action_copy()}
+              aria-label={m.action_copy()}
+              onclick={() => copyField("sshPrivateKey", "clé privée")}
+            >
+              <Icon name="copy" size={14} />
+            </button>
+          </dd>
+        </div>
       {/if}
     </section>
   {/if}

--- a/src/lib/CipherDetail.svelte
+++ b/src/lib/CipherDetail.svelte
@@ -262,14 +262,14 @@
     </section>
   {/if}
 
-  {#if detail.login?.totp}
+  {#if detail.login?.hasTotp}
     <section class="detail-section">
       <h3 class="detail-section-title">{m.detail_section_security()}</h3>
       <div class="detail-field" role="group">
         <dt>{m.detail_field_totp()}</dt>
         <dd>
           <TotpField
-            source={detail.login.totp}
+            id={detail.id}
             onCopy={(code) => onCopy(code, m.detail_field_totp())}
           />
         </dd>

--- a/src/lib/CipherDetail.svelte
+++ b/src/lib/CipherDetail.svelte
@@ -241,14 +241,14 @@
     </section>
   {/if}
 
-  {#if detail.login?.totp}
+  {#if detail.login?.hasTotp}
     <section class="detail-section">
       <h3 class="detail-section-title">{m.detail_section_security()}</h3>
       <div class="detail-field" role="group">
         <dt>{m.detail_field_totp()}</dt>
         <dd>
           <TotpField
-            source={detail.login.totp}
+            id={detail.id}
             onCopy={(code) => onCopy(code, m.detail_field_totp())}
           />
         </dd>

--- a/src/lib/CipherDetail.svelte
+++ b/src/lib/CipherDetail.svelte
@@ -3,7 +3,7 @@
   import Icon from "./Icon.svelte";
   import TotpField from "./TotpField.svelte";
   import { api } from "./api";
-  import { cipherTypeLabel, mask } from "./format";
+  import { cipherTypeLabel } from "./format";
   import type { CipherDetail, CipherSummary, OrganizationSummary } from "./types";
 
   type Props = {
@@ -53,6 +53,12 @@
   async function copyField(field: string, label: string) {
     const value = await revealValue(field);
     if (value) await onCopy(value, label);
+  }
+
+  /** Reveal-toggle a secret field: fetch it before showing. */
+  async function toggleSecret(field: string, shown: boolean, set: (v: boolean) => void) {
+    if (!shown) await revealValue(field);
+    set(!shown);
   }
 
   $effect(() => {
@@ -141,12 +147,13 @@
 
 {#snippet secretField(
   label: string,
-  value: string,
+  field: string,
   shown: boolean,
   toggle: () => void,
   copyAs: string,
   options?: { masked?: string; renderShown?: "default" | "password" | "ssh" }
 )}
+  {@const value = revealed[field] ?? ""}
   <div class="detail-field" role="group">
     <dt>{label}</dt>
     <dd>
@@ -159,7 +166,7 @@
       {:else if shown}
         <code class="value">{value}</code>
       {:else}
-        <code class="value">{options?.masked ?? "•".repeat(Math.min(value.length, 16))}</code>
+        <code class="value">{options?.masked ?? "••••••••"}</code>
       {/if}
       <button
         type="button"
@@ -175,7 +182,7 @@
         class="icon-btn primary"
         title={m.action_copy()}
         aria-label={m.action_copy()}
-        onclick={() => onCopy(value, copyAs)}
+        onclick={() => copyField(field, copyAs)}
       >
         <Icon name="copy" size={14} />
       </button>
@@ -219,18 +226,18 @@
     </div>
   </header>
 
-  {#if detail.login && (detail.login.username || detail.login.password)}
+  {#if detail.login && (detail.login.username || detail.login.hasPassword)}
     <section class="detail-section">
       <h3 class="detail-section-title">{m.detail_section_credentials()}</h3>
       {#if detail.login.username}
         {@render plainField(m.detail_field_username(), detail.login.username, "identifiant")}
       {/if}
-      {#if detail.login.password}
+      {#if detail.login.hasPassword}
         {@render secretField(
           m.detail_field_password(),
-          detail.login.password,
+          "password",
           showPassword,
-          () => (showPassword = !showPassword),
+          () => toggleSecret("password", showPassword, (v) => (showPassword = v)),
           "mot de passe",
           { renderShown: "password" }
         )}
@@ -289,14 +296,14 @@
           <dd><span class="value">{detail.card.brand}</span></dd>
         </div>
       {/if}
-      {#if detail.card.number}
+      {#if detail.card.hasNumber}
         {@render secretField(
           m.detail_field_number(),
-          detail.card.number,
+          "cardNumber",
           showCardNumber,
-          () => (showCardNumber = !showCardNumber),
+          () => toggleSecret("cardNumber", showCardNumber, (v) => (showCardNumber = v)),
           "numéro de carte",
-          { masked: mask(detail.card.number, 16) }
+          { masked: "•••• •••• •••• ••••" }
         )}
       {/if}
       {#if detail.card.expMonth || detail.card.expYear}
@@ -309,14 +316,14 @@
           </dd>
         </div>
       {/if}
-      {#if detail.card.code}
+      {#if detail.card.hasCode}
         {@render secretField(
           m.detail_field_cvv(),
-          detail.card.code,
+          "cardCode",
           showCardCode,
-          () => (showCardCode = !showCardCode),
+          () => toggleSecret("cardCode", showCardCode, (v) => (showCardCode = v)),
           "CVV",
-          { masked: mask(detail.card.code, 3) }
+          { masked: "•••" }
         )}
       {/if}
     </section>
@@ -330,14 +337,14 @@
           {@render plainField(label, value)}
         {/if}
       {/each}
-      {#if detail.identity.ssn}
+      {#if detail.identity.hasSsn}
         {@render secretField(
           m.detail_field_ssn(),
-          detail.identity.ssn,
+          "ssn",
           showSsn,
-          () => (showSsn = !showSsn),
+          () => toggleSecret("ssn", showSsn, (v) => (showSsn = v)),
           "NIR",
-          { masked: mask(detail.identity.ssn, 11) }
+          { masked: "•••••••••" }
         )}
       {/if}
     </section>
@@ -367,37 +374,14 @@
         </div>
       {/if}
       {#if detail.sshKey.hasPrivateKey}
-        <div class="detail-field" role="group">
-          <dt>{m.detail_field_private_key()}</dt>
-          <dd>
-            {#if showSshPrivate}
-              <code class="value ssh-key">{revealed["sshPrivateKey"] ?? ""}</code>
-            {:else}
-              <code class="value">{m.detail_field_private_key_hidden()}</code>
-            {/if}
-            <button
-              type="button"
-              class="icon-btn"
-              title={showSshPrivate ? m.action_hide_value() : m.action_show()}
-              aria-label={showSshPrivate ? m.action_hide_value() : m.action_show()}
-              onclick={async () => {
-                if (!showSshPrivate) await revealValue("sshPrivateKey");
-                showSshPrivate = !showSshPrivate;
-              }}
-            >
-              <Icon name={showSshPrivate ? "eye-off" : "eye"} size={14} />
-            </button>
-            <button
-              type="button"
-              class="icon-btn primary"
-              title={m.action_copy()}
-              aria-label={m.action_copy()}
-              onclick={() => copyField("sshPrivateKey", "clé privée")}
-            >
-              <Icon name="copy" size={14} />
-            </button>
-          </dd>
-        </div>
+        {@render secretField(
+          m.detail_field_private_key(),
+          "sshPrivateKey",
+          showSshPrivate,
+          () => toggleSecret("sshPrivateKey", showSshPrivate, (v) => (showSshPrivate = v)),
+          "clé privée",
+          { masked: m.detail_field_private_key_hidden(), renderShown: "ssh" }
+        )}
       {/if}
     </section>
   {/if}

--- a/src/lib/ExportDialog.svelte
+++ b/src/lib/ExportDialog.svelte
@@ -74,8 +74,11 @@
         const detail = await api.getCipher(c.id);
         const folder = c.folderId ? (folderById.get(c.folderId) ?? "") : "";
         if (detail.kind === 1) {
-          // The TOTP secret isn't in `detail` anymore; fetch the raw seed for
-          // export (a legitimate "get my secrets out" path).
+          // The password and TOTP secret aren't in `detail` anymore; fetch the
+          // raw values for export (a legitimate "get my secrets out" path).
+          const loginPassword = detail.login?.hasPassword
+            ? ((await api.revealField(c.id, "password")) ?? "")
+            : "";
           const loginTotp = detail.login?.hasTotp
             ? ((await api.revealLoginTotp(c.id)) ?? "")
             : "";
@@ -87,7 +90,7 @@
             notes: detail.notes ?? "",
             loginUris: detail.login?.uris ?? [],
             loginUsername: detail.login?.username ?? "",
-            loginPassword: detail.login?.password ?? "",
+            loginPassword,
             loginTotp,
           });
         } else if (detail.kind === 2) {

--- a/src/lib/ExportDialog.svelte
+++ b/src/lib/ExportDialog.svelte
@@ -74,6 +74,11 @@
         const detail = await api.getCipher(c.id);
         const folder = c.folderId ? (folderById.get(c.folderId) ?? "") : "";
         if (detail.kind === 1) {
+          // The TOTP secret isn't in `detail` anymore; fetch the raw seed for
+          // export (a legitimate "get my secrets out" path).
+          const loginTotp = detail.login?.hasTotp
+            ? ((await api.revealLoginTotp(c.id)) ?? "")
+            : "";
           rows.push({
             folder,
             favorite: detail.favorite,
@@ -83,7 +88,7 @@
             loginUris: detail.login?.uris ?? [],
             loginUsername: detail.login?.username ?? "",
             loginPassword: detail.login?.password ?? "",
-            loginTotp: detail.login?.totp ?? "",
+            loginTotp,
           });
         } else if (detail.kind === 2) {
           rows.push({

--- a/src/lib/TotpField.svelte
+++ b/src/lib/TotpField.svelte
@@ -1,41 +1,37 @@
 <script lang="ts">
   import * as m from "$lib/paraglide/messages";
-  import { generateTotp, parseTotp, secondsRemaining, type TotpConfig } from "$lib/totp";
+  import { api } from "$lib/api";
 
-  let { source, onCopy }: { source: string; onCopy: (code: string) => void } = $props();
-
-  // Derive config/error purely from `source`. No $state is both written and
-  // read inside an effect, so there is no self-referential update loop.
-  const parsed = $derived.by((): { config: TotpConfig | null; error: string | null } => {
-    try {
-      return { config: parseTotp(source), error: null };
-    } catch (e) {
-      return { config: null, error: (e as Error).message };
-    }
-  });
-  const config = $derived(parsed.config);
-  const parseError = $derived(parsed.error);
+  // The TOTP secret stays in Rust; we ask the backend for the current code
+  // once a second. `id` is the cipher id.
+  let { id, onCopy }: { id: string; onCopy: (code: string) => void } = $props();
 
   let code = $state<string>("");
   let remaining = $state<number>(30);
+  let parseError = $state<string | null>(null);
 
-  // Timer lives in its own effect that depends only on `config`. It writes
-  // `code`/`remaining` but never reads them, so it cannot re-trigger itself.
+  // Poll `totp_code` for the given item. Writes code/remaining but never reads
+  // them, so it can't re-trigger itself; re-runs only when `id` changes.
   $effect(() => {
-    const cfg = config;
+    const cipherId = id;
     code = "";
-    if (!cfg) return;
+    parseError = null;
 
     let cancelled = false;
-    async function tick(c: TotpConfig) {
-      const now = Math.floor(Date.now() / 1000);
-      remaining = secondsRemaining(c.period, now);
-      const next = await generateTotp(c, now);
-      if (!cancelled) code = next;
+    async function tick() {
+      try {
+        const res = await api.totpCode(cipherId);
+        if (!cancelled) {
+          code = res.code;
+          remaining = res.secondsRemaining;
+        }
+      } catch (e) {
+        if (!cancelled) parseError = (e as Error).message ?? String(e);
+      }
     }
 
-    void tick(cfg);
-    const timer = setInterval(() => void tick(cfg), 1000);
+    void tick();
+    const timer = setInterval(() => void tick(), 1000);
 
     return () => {
       cancelled = true;
@@ -51,7 +47,7 @@
 
 {#if parseError}
   <span class="totp-error">{parseError}</span>
-{:else if config && code}
+{:else if code}
   <span class="totp-code">{formatCode(code)}</span>
   <span class="totp-remaining" class:soon={remaining <= 5}>{remaining}s</span>
   <button type="button" class="secondary small" onclick={() => onCopy(code)}>

--- a/src/lib/TotpField.svelte.test.ts
+++ b/src/lib/TotpField.svelte.test.ts
@@ -1,6 +1,15 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, cleanup, waitFor } from "@testing-library/svelte";
+
+// The TOTP secret stays in Rust; TotpField asks `api.totpCode(id)` for the
+// current code. Mock that so the component test doesn't need a Tauri backend.
+vi.mock("./api", () => ({
+  api: {
+    totpCode: vi.fn().mockResolvedValue({ code: "287082", secondsRemaining: 12 }),
+  },
+}));
+
 import TotpField from "./TotpField.svelte";
 
 afterEach(() => {
@@ -30,7 +39,7 @@ describe("TotpField reactivity", () => {
     try {
       render(TotpField, {
         // RFC 6238 test secret ("12345678901234567890" base32-encoded)
-        props: { source: "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ", onCopy: () => {} },
+        props: { id: "cipher-1", onCopy: () => {} },
       });
     } catch (e) {
       threw = e;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -133,6 +133,12 @@ export const api = {
 
   getCipher: (id: string) => invoke<CipherDetail>("get_cipher", { id }),
 
+  /** Decrypt a single secret field on demand (kept out of get_cipher / JS
+      reactive state). field: password | cardNumber | cardCode | ssn |
+      sshPrivateKey. */
+  revealField: (id: string, field: string) =>
+    invoke<string | null>("reveal_field", { id, field }),
+
   createCipher: (input: EditorPayload) =>
     invoke<string>("create_cipher", { input: payloadToRust(input) }),
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   SshAgentStatus,
   StoredAccount,
   SyncSummary,
+  TotpCode,
 } from "./types";
 
 function nullIfEmpty(s: string): string | null {
@@ -132,6 +133,13 @@ export const api = {
     invoke<void>("rename_folder_path", { sourcePath, newPath }),
 
   getCipher: (id: string) => invoke<CipherDetail>("get_cipher", { id }),
+
+  /** Current TOTP code + seconds remaining, computed in Rust (the seed never
+      reaches JS). */
+  totpCode: (id: string) => invoke<TotpCode>("totp_code", { id }),
+
+  /** Raw TOTP secret — only for the editor and export. */
+  revealLoginTotp: (id: string) => invoke<string | null>("reveal_login_totp", { id }),
 
   createCipher: (input: EditorPayload) =>
     invoke<string>("create_cipher", { input: payloadToRust(input) }),

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   SshAgentStatus,
   StoredAccount,
   SyncSummary,
+  TotpCode,
 } from "./types";
 
 function nullIfEmpty(s: string): string | null {
@@ -138,6 +139,13 @@ export const api = {
       sshPrivateKey. */
   revealField: (id: string, field: string) =>
     invoke<string | null>("reveal_field", { id, field }),
+
+  /** Current TOTP code + seconds remaining, computed in Rust (the seed never
+      reaches JS). */
+  totpCode: (id: string) => invoke<TotpCode>("totp_code", { id }),
+
+  /** Raw TOTP secret — only for the editor and export. */
+  revealLoginTotp: (id: string) => invoke<string | null>("reveal_login_totp", { id }),
 
   createCipher: (input: EditorPayload) =>
     invoke<string>("create_cipher", { input: payloadToRust(input) }),

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -15,6 +15,8 @@ export type VaultKeyDeps = {
   closeDetail: () => void;
   lock: () => Promise<void> | void;
   copy: (value: string, label: string) => Promise<void> | void;
+  /** Reveal the password for a cipher id on demand (kept out of `detail`). */
+  getPassword: (cipherId: string) => Promise<string>;
   /** Current TOTP code for a cipher id (computed in Rust). */
   getTotpCode: (cipherId: string) => Promise<string>;
   onError: (e: unknown) => void;
@@ -57,9 +59,14 @@ export function makeVaultKeyHandler(deps: VaultKeyDeps) {
     if (isTypingContext()) return;
     const selectionLength = window.getSelection()?.toString().length ?? 0;
     if (!detail || selectionLength > 0) return;
-    if (key === "c" && detail.login?.password) {
+    if (key === "c" && detail.login?.hasPassword) {
       event.preventDefault();
-      await deps.copy(detail.login.password, "mot de passe");
+      try {
+        const password = await deps.getPassword(detail.id);
+        if (password) await deps.copy(password, "mot de passe");
+      } catch (e) {
+        deps.onError(e);
+      }
       return;
     }
     if (key === "b" && detail.login?.username) {

--- a/src/lib/keyboard.ts
+++ b/src/lib/keyboard.ts
@@ -1,5 +1,4 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { currentTotpCode } from "./totp";
 import type { CipherDetail } from "./types";
 
 function isTypingContext(): boolean {
@@ -16,6 +15,8 @@ export type VaultKeyDeps = {
   closeDetail: () => void;
   lock: () => Promise<void> | void;
   copy: (value: string, label: string) => Promise<void> | void;
+  /** Current TOTP code for a cipher id (computed in Rust). */
+  getTotpCode: (cipherId: string) => Promise<string>;
   onError: (e: unknown) => void;
 };
 
@@ -66,10 +67,10 @@ export function makeVaultKeyHandler(deps: VaultKeyDeps) {
       await deps.copy(detail.login.username, "identifiant");
       return;
     }
-    if (key === "t" && detail.login?.totp) {
+    if (key === "t" && detail.login?.hasTotp) {
       event.preventDefault();
       try {
-        const code = await currentTotpCode(detail.login.totp);
+        const code = await deps.getTotpCode(detail.id);
         await deps.copy(code, "code TOTP");
       } catch (e) {
         deps.onError(e);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,7 +71,8 @@ export type SyncSummary = {
 
 export type LoginDetail = {
   username: string | null;
-  password: string | null;
+  /** Presence only — fetch with `api.revealField(id, "password")`. */
+  hasPassword: boolean;
   uris: string[];
   /** The TOTP secret never crosses to JS — only whether the item has one.
       Use `api.totpCode(id)` for the current code, `api.revealLoginTotp(id)`
@@ -87,10 +88,10 @@ export type TotpCode = {
 export type CardDetail = {
   cardholderName: string | null;
   brand: string | null;
-  number: string | null;
+  hasNumber: boolean;
   expMonth: string | null;
   expYear: string | null;
-  code: string | null;
+  hasCode: boolean;
 };
 
 export type IdentityDetail = {
@@ -108,7 +109,7 @@ export type IdentityDetail = {
   company: string | null;
   email: string | null;
   phone: string | null;
-  ssn: string | null;
+  hasSsn: boolean;
   username: string | null;
   passportNumber: string | null;
   licenseNumber: string | null;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,7 +73,15 @@ export type LoginDetail = {
   username: string | null;
   password: string | null;
   uris: string[];
-  totp: string | null;
+  /** The TOTP secret never crosses to JS — only whether the item has one.
+      Use `api.totpCode(id)` for the current code, `api.revealLoginTotp(id)`
+      for the raw secret (editor/export only). */
+  hasTotp: boolean;
+};
+
+export type TotpCode = {
+  code: string;
+  secondsRemaining: number;
 };
 
 export type CardDetail = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,7 +107,9 @@ export type IdentityDetail = {
 };
 
 export type SshKeyDetail = {
-  privateKey: string | null;
+  /** The private key stays in Rust; fetch on demand with
+      `api.revealField(id, "sshPrivateKey")`. */
+  hasPrivateKey: boolean;
   publicKey: string | null;
   keyFingerprint: string | null;
 };

--- a/src/lib/vault.svelte.ts
+++ b/src/lib/vault.svelte.ts
@@ -357,7 +357,18 @@ export class VaultController {
     this.editorOpen = true;
   }
 
-  openEditEditor() {
+  async openEditEditor() {
+    if (!this.detail) return;
+    // The SSH private key is no longer in `detail`; fetch it so the editor can
+    // keep it (otherwise saving would wipe the key).
+    let sshPrivateKey = "";
+    if (this.detail.sshKey?.hasPrivateKey) {
+      try {
+        sshPrivateKey = (await api.revealField(this.detail.id, "sshPrivateKey")) ?? "";
+      } catch (e) {
+        this.error = formatError(e);
+      }
+    }
     if (!this.detail) return;
     const currentCipher = this.summary?.ciphers.find((c) => c.id === this.detail!.id);
     const kind = (this.detail.kind as 1 | 2 | 3 | 4 | 5) ?? 1;
@@ -402,7 +413,7 @@ export class VaultController {
         licenseNumber: this.detail.identity?.licenseNumber ?? "",
       },
       sshKey: {
-        privateKey: this.detail.sshKey?.privateKey ?? "",
+        privateKey: sshPrivateKey,
         publicKey: this.detail.sshKey?.publicKey ?? "",
         keyFingerprint: this.detail.sshKey?.keyFingerprint ?? "",
       },

--- a/src/lib/vault.svelte.ts
+++ b/src/lib/vault.svelte.ts
@@ -363,12 +363,29 @@ export class VaultController {
     // saving them back doesn't wipe them.
     let sshPrivateKey = "";
     let totpSecret = "";
+    let password = "";
+    let cardNumber = "";
+    let cardCode = "";
+    let ssn = "";
     try {
+      const id = this.detail.id;
+      if (this.detail.login?.hasPassword) {
+        password = (await api.revealField(id, "password")) ?? "";
+      }
+      if (this.detail.card?.hasNumber) {
+        cardNumber = (await api.revealField(id, "cardNumber")) ?? "";
+      }
+      if (this.detail.card?.hasCode) {
+        cardCode = (await api.revealField(id, "cardCode")) ?? "";
+      }
+      if (this.detail.identity?.hasSsn) {
+        ssn = (await api.revealField(id, "ssn")) ?? "";
+      }
       if (this.detail.sshKey?.hasPrivateKey) {
-        sshPrivateKey = (await api.revealField(this.detail.id, "sshPrivateKey")) ?? "";
+        sshPrivateKey = (await api.revealField(id, "sshPrivateKey")) ?? "";
       }
       if (this.detail.login?.hasTotp) {
-        totpSecret = (await api.revealLoginTotp(this.detail.id)) ?? "";
+        totpSecret = (await api.revealLoginTotp(id)) ?? "";
       }
     } catch (e) {
       this.error = formatError(e);
@@ -385,16 +402,16 @@ export class VaultController {
       favorite: currentCipher?.favorite ?? false,
       notes: this.detail.notes ?? "",
       username: this.detail.login?.username ?? "",
-      password: this.detail.login?.password ?? "",
+      password,
       uris: this.detail.login?.uris ?? [],
       totp: totpSecret,
       card: {
         cardholderName: this.detail.card?.cardholderName ?? "",
         brand: this.detail.card?.brand ?? "",
-        number: this.detail.card?.number ?? "",
+        number: cardNumber,
         expMonth: this.detail.card?.expMonth ?? "",
         expYear: this.detail.card?.expYear ?? "",
-        code: this.detail.card?.code ?? "",
+        code: cardCode,
       },
       identity: {
         title: this.detail.identity?.title ?? "",
@@ -411,7 +428,7 @@ export class VaultController {
         company: this.detail.identity?.company ?? "",
         email: this.detail.identity?.email ?? "",
         phone: this.detail.identity?.phone ?? "",
-        ssn: this.detail.identity?.ssn ?? "",
+        ssn,
         username: this.detail.identity?.username ?? "",
         passportNumber: this.detail.identity?.passportNumber ?? "",
         licenseNumber: this.detail.identity?.licenseNumber ?? "",

--- a/src/lib/vault.svelte.ts
+++ b/src/lib/vault.svelte.ts
@@ -357,7 +357,18 @@ export class VaultController {
     this.editorOpen = true;
   }
 
-  openEditEditor() {
+  async openEditEditor() {
+    if (!this.detail) return;
+    // The TOTP secret is no longer in `detail` (it stays in Rust); fetch the
+    // raw seed so the editor can show/keep it — otherwise saving would wipe it.
+    let totpSecret = "";
+    if (this.detail.login?.hasTotp) {
+      try {
+        totpSecret = (await api.revealLoginTotp(this.detail.id)) ?? "";
+      } catch (e) {
+        this.error = formatError(e);
+      }
+    }
     if (!this.detail) return;
     const currentCipher = this.summary?.ciphers.find((c) => c.id === this.detail!.id);
     const kind = (this.detail.kind as 1 | 2 | 3 | 4 | 5) ?? 1;
@@ -372,7 +383,7 @@ export class VaultController {
       username: this.detail.login?.username ?? "",
       password: this.detail.login?.password ?? "",
       uris: this.detail.login?.uris ?? [],
-      totp: this.detail.login?.totp ?? "",
+      totp: totpSecret,
       card: {
         cardholderName: this.detail.card?.cardholderName ?? "",
         brand: this.detail.card?.brand ?? "",

--- a/src/lib/vault.svelte.ts
+++ b/src/lib/vault.svelte.ts
@@ -359,15 +359,19 @@ export class VaultController {
 
   async openEditEditor() {
     if (!this.detail) return;
-    // The SSH private key is no longer in `detail`; fetch it so the editor can
-    // keep it (otherwise saving would wipe the key).
+    // Secrets are no longer in `detail`; fetch the ones the editor edits so
+    // saving them back doesn't wipe them.
     let sshPrivateKey = "";
-    if (this.detail.sshKey?.hasPrivateKey) {
-      try {
+    let totpSecret = "";
+    try {
+      if (this.detail.sshKey?.hasPrivateKey) {
         sshPrivateKey = (await api.revealField(this.detail.id, "sshPrivateKey")) ?? "";
-      } catch (e) {
-        this.error = formatError(e);
       }
+      if (this.detail.login?.hasTotp) {
+        totpSecret = (await api.revealLoginTotp(this.detail.id)) ?? "";
+      }
+    } catch (e) {
+      this.error = formatError(e);
     }
     if (!this.detail) return;
     const currentCipher = this.summary?.ciphers.find((c) => c.id === this.detail!.id);
@@ -383,7 +387,7 @@ export class VaultController {
       username: this.detail.login?.username ?? "",
       password: this.detail.login?.password ?? "",
       uris: this.detail.login?.uris ?? [],
-      totp: this.detail.login?.totp ?? "",
+      totp: totpSecret,
       card: {
         cardholderName: this.detail.card?.cardholderName ?? "",
         brand: this.detail.card?.brand ?? "",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,7 +29,6 @@
   import { formatError } from "$lib/format";
   import { startSplitterDrag } from "$lib/splitter";
   import { makeVaultKeyHandler } from "$lib/keyboard";
-  import { currentTotpCode } from "$lib/totp";
   import { openUrl } from "@tauri-apps/plugin-opener";
   import type { CipherDetail as CipherDetailData, CipherSummary } from "$lib/types";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
@@ -150,11 +149,13 @@
   }
 
   async function copyMenuTotp() {
-    const source = menuDetail?.login?.totp;
+    const id = menuCipher?.id;
+    const hasTotp = menuDetail?.login?.hasTotp;
     closeRowMenu();
-    if (!source) return;
+    if (!id || !hasTotp) return;
     try {
-      await copyToClipboard(await currentTotpCode(source), "code TOTP");
+      const { code } = await api.totpCode(id);
+      await copyToClipboard(code, "code TOTP");
     } catch (e) {
       vault.error = formatError(e);
     }
@@ -217,6 +218,7 @@
     closeDetail: () => vault.closeDetail(),
     lock: () => lockAndReset(),
     copy: copyToClipboard,
+    getTotpCode: async (id) => (await api.totpCode(id)).code,
     onError: (e) => (vault.error = formatError(e)),
   });
 
@@ -481,7 +483,7 @@
         <kbd class="ctx-shortcut">Ctrl+C</kbd>
       </button>
     {/if}
-    {#if menuDetail?.login?.totp}
+    {#if menuDetail?.login?.hasTotp}
       <button type="button" role="menuitem" onclick={copyMenuTotp}>
         <span class="ctx-label">{m.ctx_copy_totp()}</span>
         <kbd class="ctx-shortcut">Ctrl+T</kbd>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -143,9 +143,16 @@
   }
 
   async function copyMenuPassword() {
-    const password = menuDetail?.login?.password;
+    const id = menuCipher?.id;
+    const hasPassword = menuDetail?.login?.hasPassword;
     closeRowMenu();
-    if (password) await copyToClipboard(password, "mot de passe");
+    if (!id || !hasPassword) return;
+    try {
+      const password = await api.revealField(id, "password");
+      if (password) await copyToClipboard(password, "mot de passe");
+    } catch (e) {
+      vault.error = formatError(e);
+    }
   }
 
   async function copyMenuTotp() {
@@ -218,6 +225,7 @@
     closeDetail: () => vault.closeDetail(),
     lock: () => lockAndReset(),
     copy: copyToClipboard,
+    getPassword: async (id) => (await api.revealField(id, "password")) ?? "",
     getTotpCode: async (id) => (await api.totpCode(id)).code,
     onError: (e) => (vault.error = formatError(e)),
   });
@@ -477,7 +485,7 @@
         <kbd class="ctx-shortcut">Ctrl+B</kbd>
       </button>
     {/if}
-    {#if menuDetail?.login?.password}
+    {#if menuDetail?.login?.hasPassword}
       <button type="button" role="menuitem" onclick={copyMenuPassword}>
         <span class="ctx-label">{m.ctx_copy_password()}</span>
         <kbd class="ctx-shortcut">Ctrl+C</kbd>


### PR DESCRIPTION
## What

Completes the **secrets-to-JS boundary** refactor. `get_cipher` no longer returns decrypted passwords, card numbers, card CVVs, or identity SSNs — it reports only their **presence** (`hasPassword` / `hasNumber` / `hasCode` / `hasSsn`). The full plaintext is fetched on demand through the existing `reveal_field` command and held only transiently while shown/copied, so complete secrets no longer sit in long-lived Svelte reactive state where a compromised renderer could scrape the whole vault from memory.

This is **L1** from the multi-agent security review, finishing the boundary work started by:
- #152 — TOTP computed in Rust, seed never crosses to JS (M4)
- #153 — SSH private key reveal-on-demand (L1a)

## Changes

**Rust**
- `models.rs`: `LoginDetail.password → has_password`, `CardDetail.number/code → has_number/has_code`, `IdentityDetail.ssn → has_ssn`.
- `commands/cipher.rs`: `get_cipher` computes the `has_*` booleans via a `present()` helper (decrypts under the item/owning key, checks non-empty). `reveal_field` already serves `password`/`cardNumber`/`cardCode`/`ssn`/`sshPrivateKey`.

**Frontend**
- `CipherDetail.svelte`: the `secretField` snippet now takes a field name and pulls the value lazily on reveal/copy; the SSH block folds into the same snippet.
- `vault.openEditEditor`: fetches password/cardNumber/cardCode/ssn so saving the editor doesn't wipe them.
- `ExportDialog.svelte`: reveals the password per row for CSV export.
- context menu + Ctrl+C: reveal the password on demand via a new `getPassword` key-handler dep.

## Stacking

Branch includes the #152 and #153 commits. **Merge after #152 and #153** — this PR's diff then reduces to the L1b delta only.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` — pass
- `pnpm check` — 0 errors
- `pnpm test` — 126 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)