### PR TITLE
feat(update): notify when a newer version is available, with a link

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -311,5 +311,9 @@
   "err_crypto": "Crypto error: {reason}",
   "err_two_factor_provider_unsupported": "Unsupported 2FA provider: {provider}",
   "err_not_authenticated": "No active session — please sign in.",
-  "err_storage": "Local storage error: {reason}"
+  "err_storage": "Local storage error: {reason}",
+  "update_available_title": "New version available",
+  "update_available_body": "Clavix {version} is available (you're on {current}).",
+  "update_action_view": "View release",
+  "update_action_dismiss": "Dismiss"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -311,5 +311,9 @@
   "err_crypto": "Erreur cryptographique : {reason}",
   "err_two_factor_provider_unsupported": "Provider 2FA non supporté : {provider}",
   "err_not_authenticated": "Aucune session active — veuillez vous connecter.",
-  "err_storage": "Erreur de stockage local : {reason}"
+  "err_storage": "Erreur de stockage local : {reason}",
+  "update_available_title": "Nouvelle version disponible",
+  "update_available_body": "Clavix {version} est disponible (vous utilisez la {current}).",
+  "update_action_view": "Voir la version",
+  "update_action_dismiss": "Ignorer"
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -5,4 +5,5 @@ pub mod import;
 pub mod move_share;
 pub mod ssh;
 pub mod tray;
+pub mod update;
 pub mod vault;

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -1,0 +1,11 @@
+use crate::error::Result;
+use crate::update::{self, UpdateInfo};
+
+/// Ask GitHub whether a newer Clavix has been published. No session required —
+/// this is a plain outbound check that returns a small verdict to the WebView
+/// (see `crate::update` for why it lives in Rust rather than JS). Errors are
+/// propagated; the frontend swallows them so a failed check is silent.
+#[tauri::command]
+pub async fn check_for_update() -> Result<UpdateInfo> {
+    update::check_for_update().await
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub mod state;
 // access to load_session / save_session / clear_session.
 pub mod store;
 mod totp;
+mod update;
 mod webauthn;
 mod yubikey_unlock;
 
@@ -162,6 +163,7 @@ pub fn run() {
             commands::tray::set_hide_dock_on_tray,
             commands::tray::set_tray_locale,
             commands::import::parse_kdbx,
+            commands::update::check_for_update,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/update.rs
+++ b/src-tauri/src/update.rs
@@ -1,0 +1,129 @@
+//! Update check: ask the GitHub Releases API whether a newer Clavix is out.
+//!
+//! This runs in Rust — never in the WebView — on purpose. The renderer's CSP
+//! (`connect-src 'self' ipc:`) deliberately forbids reaching any external host,
+//! so a compromised renderer can't exfiltrate the vault. The version check is
+//! the one "phone home" the app makes besides HIBP, and keeping it behind an
+//! IPC command preserves that boundary: JS only ever sees a small verdict
+//! struct, never gets to make the outbound request itself.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{Error, Result};
+
+const RELEASES_LATEST_API: &str = "https://api.github.com/repos/Upellift99/clavix/releases/latest";
+const USER_AGENT: &str = concat!("Clavix/", env!("CARGO_PKG_VERSION"));
+
+/// Verdict handed to the WebView. `update_available` is the only thing the UI
+/// really acts on; the rest lets it render "vX.Y.Z is available" + a link.
+#[derive(Debug, Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateInfo {
+    /// The version this build reports (`CARGO_PKG_VERSION`).
+    pub current: String,
+    /// The latest published release's version, tag stripped of a leading `v`.
+    pub latest: String,
+    /// True only when `latest` parses as a strictly-greater semver than
+    /// `current`. A malformed/older/equal tag yields false — we never nag on
+    /// something we can't confidently compare.
+    pub update_available: bool,
+    /// The release's human page on GitHub, opened via the system browser.
+    pub url: String,
+}
+
+/// Minimal shape of the GitHub "latest release" payload.
+#[derive(Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    html_url: String,
+}
+
+/// Parse a `vX.Y.Z` (or `X.Y.Z`) tag into a comparable triple. Extra
+/// pre-release/build suffix after the patch number is ignored — Clavix ships
+/// plain release-please tags, so this covers every real tag while refusing to
+/// guess on anything odd (returns None → treated as "no update").
+fn parse_semver(tag: &str) -> Option<(u64, u64, u64)> {
+    let core = tag.trim().trim_start_matches('v');
+    // Drop any pre-release/build metadata so "1.2.3-rc1" still compares by core.
+    let core = core.split(['-', '+']).next().unwrap_or(core);
+    let mut parts = core.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next()?.parse().ok()?;
+    Some((major, minor, patch))
+}
+
+/// Query GitHub for the latest release and compare it to this build. Network
+/// or parse failures surface as `Err` — the caller (command) decides whether to
+/// swallow them, but a failed check must never disrupt the app.
+pub async fn check_for_update() -> Result<UpdateInfo> {
+    let current = env!("CARGO_PKG_VERSION").to_string();
+
+    let client = reqwest::Client::builder().build()?;
+    let response = client
+        .get(RELEASES_LATEST_API)
+        .header("User-Agent", USER_AGENT)
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .send()
+        .await?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(Error::HttpStatus {
+            status: status.as_u16(),
+            message: "GitHub releases API error".into(),
+        });
+    }
+
+    let release: GithubRelease = response.json().await.map_err(|e| Error::InvalidResponse {
+        reason: format!("could not parse GitHub release JSON: {e}"),
+    })?;
+
+    let latest = release.tag_name.trim_start_matches('v').to_string();
+    let update_available = match (parse_semver(&current), parse_semver(&release.tag_name)) {
+        (Some(cur), Some(new)) => new > cur,
+        _ => false,
+    };
+
+    Ok(UpdateInfo {
+        current,
+        latest,
+        update_available,
+        url: release.html_url,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_plain_and_v_prefixed_tags() {
+        assert_eq!(parse_semver("v0.5.0"), Some((0, 5, 0)));
+        assert_eq!(parse_semver("1.2.3"), Some((1, 2, 3)));
+        assert_eq!(parse_semver(" v10.20.30 "), Some((10, 20, 30)));
+    }
+
+    #[test]
+    fn ignores_prerelease_and_build_suffixes() {
+        assert_eq!(parse_semver("v1.2.3-rc1"), Some((1, 2, 3)));
+        assert_eq!(parse_semver("1.2.3+build7"), Some((1, 2, 3)));
+    }
+
+    #[test]
+    fn rejects_malformed_tags() {
+        assert_eq!(parse_semver("nightly"), None);
+        assert_eq!(parse_semver("v1.2"), None);
+        assert_eq!(parse_semver(""), None);
+    }
+
+    #[test]
+    fn newer_tag_is_greater() {
+        assert!(parse_semver("v0.5.0") > parse_semver("v0.4.9"));
+        assert!(parse_semver("v1.0.0") > parse_semver("v0.9.9"));
+        assert!(parse_semver("v0.4.1") > parse_semver("v0.4.0"));
+        assert!(parse_semver("v0.4.0") <= parse_semver("v0.4.0"));
+        assert!(parse_semver("v0.3.0") <= parse_semver("v0.4.0"));
+    }
+}

--- a/src/lib/UpdateBanner.svelte
+++ b/src/lib/UpdateBanner.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import * as m from "$lib/paraglide/messages";
+  import Icon from "./Icon.svelte";
+  import type { UpdateInfo } from "./types";
+
+  type Props = {
+    info: UpdateInfo;
+    onView: () => void;
+    onDismiss: () => void;
+  };
+
+  let { info, onView, onDismiss }: Props = $props();
+</script>
+
+<div class="update-banner" role="status">
+  <span class="update-icon"><Icon name="download" size={16} /></span>
+  <div class="update-text">
+    <strong>{m.update_available_title()}</strong>
+    <span>{m.update_available_body({ version: info.latest, current: info.current })}</span>
+  </div>
+  <div class="update-actions">
+    <button type="button" class="primary small" onclick={onView}>
+      {m.update_action_view()}
+    </button>
+    <button
+      type="button"
+      class="icon-btn"
+      title={m.update_action_dismiss()}
+      aria-label={m.update_action_dismiss()}
+      onclick={onDismiss}
+    >
+      <Icon name="x" size={16} />
+    </button>
+  </div>
+</div>
+
+<style>
+  .update-banner {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    margin-top: 0.75rem;
+    padding: 0.55rem 0.85rem;
+    border-radius: 8px;
+    background: #eff6ff;
+    border-left: 3px solid #3b82f6;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  }
+
+  .update-icon {
+    display: inline-flex;
+    color: #2563eb;
+    flex-shrink: 0;
+  }
+
+  .update-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    min-width: 0;
+    flex: 1;
+  }
+
+  .update-text strong {
+    font-size: 0.9rem;
+  }
+
+  .update-text span {
+    font-size: 0.82rem;
+    color: #475569;
+  }
+
+  .update-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    flex-shrink: 0;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .update-banner {
+      background: #1e293b;
+      box-shadow: none;
+    }
+    .update-icon {
+      color: #60a5fa;
+    }
+    .update-text span {
+      color: #94a3b8;
+    }
+  }
+
+  :where(:root.force-dark) .update-banner {
+    background: #1e293b;
+    box-shadow: none;
+  }
+  :where(:root.force-dark) .update-icon {
+    color: #60a5fa;
+  }
+  :where(:root.force-dark) .update-text span {
+    color: #94a3b8;
+  }
+</style>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   StoredAccount,
   SyncSummary,
   TotpCode,
+  UpdateInfo,
 } from "./types";
 
 function nullIfEmpty(s: string): string | null {
@@ -189,6 +190,10 @@ export const api = {
 
   parseKdbx: (bytes: Uint8Array, password: string) =>
     invoke<KdbxEntry[]>("parse_kdbx", { bytes: Array.from(bytes), password }),
+
+  /** Ask GitHub (from Rust — the CSP blocks the WebView from reaching it)
+      whether a newer Clavix has been published. */
+  checkForUpdate: () => invoke<UpdateInfo>("check_for_update"),
 };
 
 /// Flat entry shape returned by `parse_kdbx` — mirrors the CSV

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -298,5 +298,12 @@ export type TreeNode = {
   itemCount: number;
 };
 
+export type UpdateInfo = {
+  current: string;
+  latest: string;
+  updateAvailable: boolean;
+  url: string;
+};
+
 export type SortKey = "name" | "username" | "uri";
 export type QuickFilter = "all" | "favorites" | "trash" | `type:${number}`;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,6 +13,7 @@
   import GeneratorDialog from "$lib/GeneratorDialog.svelte";
   import StatsDialog from "$lib/StatsDialog.svelte";
   import AuditDialog from "$lib/AuditDialog.svelte";
+  import UpdateBanner from "$lib/UpdateBanner.svelte";
   import { ClipboardController, type ClipboardVariant } from "$lib/clipboard.svelte";
   import { DragController } from "$lib/drag.svelte";
   import { AuthController } from "$lib/auth.svelte";
@@ -30,7 +31,7 @@
   import { startSplitterDrag } from "$lib/splitter";
   import { makeVaultKeyHandler } from "$lib/keyboard";
   import { openUrl } from "@tauri-apps/plugin-opener";
-  import type { CipherDetail as CipherDetailData, CipherSummary } from "$lib/types";
+  import type { CipherDetail as CipherDetailData, CipherSummary, UpdateInfo } from "$lib/types";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 
   const prefs = new PrefsController();
@@ -45,6 +46,24 @@
   let generatorDialog = $state<{ open: () => void } | null>(null);
   let importOpen = $state(false);
   let exportOpen = $state(false);
+
+  // Update check: populated once at startup by the Rust check (see api.checkForUpdate).
+  // The banner shows only while a newer version exists and the user hasn't
+  // dismissed it this session.
+  let updateInfo = $state<UpdateInfo | null>(null);
+  let updateDismissed = $state(false);
+  const showUpdateBanner = $derived(
+    updateInfo?.updateAvailable === true && !updateDismissed,
+  );
+
+  async function openReleasePage() {
+    if (!updateInfo) return;
+    try {
+      await openUrl(updateInfo.url);
+    } catch (e) {
+      vault.error = formatError(e);
+    }
+  }
 
   // "Show all items" is a per-session escape hatch from the gate: it lasts
   // until the vault is locked, and does not touch the stored preference.
@@ -309,6 +328,15 @@
     unlistenSessionLocked = await listen("clavix:session-locked", () => {
       lockAndReset();
     });
+    // Fire-and-forget: a failed update check must never disrupt startup, so we
+    // swallow errors (offline, rate-limited, GitHub down) and simply show no
+    // banner.
+    api
+      .checkForUpdate()
+      .then((info) => {
+        updateInfo = info;
+      })
+      .catch(() => {});
   });
 
   onDestroy(() => {
@@ -349,6 +377,13 @@
     {/if}
 
     {#if auth.phase === "loggedIn"}
+      {#if showUpdateBanner && updateInfo}
+        <UpdateBanner
+          info={updateInfo}
+          onView={openReleasePage}
+          onDismiss={() => (updateDismissed = true)}
+        />
+      {/if}
       <Toolbar
         syncing={vault.syncing}
         hasSync={vault.summary !== null}


### PR DESCRIPTION
## What

A startup **version check**. On launch, a Rust command asks the GitHub Releases API for the latest published release, compares its tag to this build's `CARGO_PKG_VERSION`, and — if a newer version exists — shows a dismissible banner at the top of the vault view with a **View release** button that opens the release page in the system browser.

![banner: "New version available — Clavix 0.5.0 is available (you're on 0.4.0)" + View release + dismiss]

## Why it lives in Rust

The renderer's CSP (`connect-src 'self' ipc:`, tightened in the security batch) deliberately forbids the WebView from reaching any external host. So the check runs in Rust and only hands JS a small verdict (`current` / `latest` / `updateAvailable` / `url`) — the renderer never makes the outbound request itself. This is the same posture as the HIBP audit.

## Behaviour

- **Silent on failure**: offline, rate-limited, or GitHub down → the promise is swallowed and no banner shows. A failed check never disrupts startup.
- **Conservative**: a malformed / older / equal tag never triggers the banner (`updateAvailable` is true only for a strictly-greater semver).
- **Per-session dismiss**: the × hides it until next launch.
- `releases/latest` auto-excludes drafts and pre-releases, matching the release-please workflow (`releaseDraft: false`).

## Changes

- `src-tauri/src/update.rs` — GitHub query + dependency-free `vX.Y.Z` semver compare (unit-tested: v-prefix, pre-release/build suffixes, malformed tags, ordering).
- `src-tauri/src/commands/update.rs` — `check_for_update` command.
- `src/lib/UpdateBanner.svelte` — theme-aware dismissible banner.
- `src/routes/+page.svelte` — fire-and-forget check on mount, banner above the toolbar.
- `src/lib/{api,types}.ts` — binding + `UpdateInfo` type.
- `messages/{fr,en}.json` — banner strings.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test` (incl. 4 new semver tests) — pass
- `pnpm check` — 0 errors · `pnpm test` — 126 pass
- Live-checked the GitHub endpoint returns the expected `tag_name` / `html_url` with our headers.

Independent of the security stack — branches off `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)