### PR TITLE
fix(ci): restore withGlobalTauri for the E2E build only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,12 @@ jobs:
       - name: Install JS dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build Clavix (debug)
-        run: pnpm tauri build --debug --no-bundle
+      - name: Build Clavix (debug, E2E config)
+        # build:e2e merges tauri.e2e.conf.json, which re-enables
+        # withGlobalTauri for the test binary only (production keeps it off,
+        # #147). The specs drive window.__TAURI__.core.invoke to seed the
+        # vault, so the global bridge must exist in the E2E build.
+        run: pnpm build:e2e
 
       - name: Run E2E suite
         # E2E_PER_SPEC_RESET=1 makes the suite wipe + reseed Vaultwarden

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "pnpm run paraglide && vitest run",
     "test:watch": "pnpm run paraglide && vitest",
     "test:e2e": "wdio run tests/e2e/wdio.conf.mjs",
+    "build:e2e": "tauri build --debug --no-bundle --config src-tauri/tauri.e2e.conf.json",
     "tauri": "tauri"
   },
   "license": "GPL-3.0-or-later",

--- a/src-tauri/tauri.e2e.conf.json
+++ b/src-tauri/tauri.e2e.conf.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "withGlobalTauri": true
+  }
+}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -24,9 +24,17 @@ pnpm install
 Build the app in debug mode, then run the suite:
 
 ```bash
-pnpm tauri build --debug
+pnpm build:e2e
 pnpm test:e2e
 ```
+
+`build:e2e` is `tauri build --debug --no-bundle` plus
+`--config src-tauri/tauri.e2e.conf.json`, which re-enables
+`withGlobalTauri` for the test binary only. Production keeps it off (#147);
+the specs need the global bridge because they drive
+`window.__TAURI__.core.invoke` directly (see below). A plain
+`pnpm tauri build --debug` produces a binary where `window.__TAURI__` is
+`undefined` and every spec fails.
 
 Headless (CI-style):
 
@@ -84,10 +92,12 @@ Two env vars to iterate locally without recycling Docker each run:
   export `WEBKIT_DISABLE_COMPOSITING_MODE=1` to force the CPU path.
 - WebdriverIO v8+ has reported regressions with `tauri-driver` — we pin
   to v7. If you update, re-run the smoke before touching anything else.
-- Tauri `withGlobalTauri=true` is intentional: the share-cipher spec
-  drives `window.__TAURI__.core.invoke` directly to bypass the flaky
-  drag-drop UI. The drag logic itself is covered by `drag.test.ts` on
-  the vitest side.
+- Tauri `withGlobalTauri` is off in production (#147, smaller attack
+  surface) but re-enabled for the E2E binary via `build:e2e`
+  (`tauri.e2e.conf.json`): several specs drive
+  `window.__TAURI__.core.invoke` directly to seed the vault and to bypass
+  the flaky drag-drop UI. The drag logic itself is covered by
+  `drag.test.ts` on the vitest side.
 - The Tauri app's data dir is sandboxed to `tests/e2e/sandbox/` via
   `XDG_DATA_HOME` so runs never touch the real `~/.local/share/clavix/`.
 


### PR DESCRIPTION
## The failure

After #147 (disable `withGlobalTauri`) landed on master, the **E2E (Tauri + WebdriverIO)** job went red — on master and on every open PR:

```
javascript error: undefined is not an object (evaluating 'window.__TAURI__.core')
```

Every spec failed. Root cause: the E2E specs drive `window.__TAURI__.core.invoke` directly to seed the vault and to bypass the flaky drag-drop UI (documented in `tests/e2e/README.md`). #147 turned off the global bridge, so the built test binary has `window.__TAURI__ === undefined`.

The app itself doesn't use the global (`src/lib/api.ts` imports `invoke` from `@tauri-apps/api/core`), so keeping it **off in production is correct** — only the test harness needs it.

## The fix

- **`src-tauri/tauri.e2e.conf.json`** — a config overlay that sets `app.withGlobalTauri: true`.
- **`build:e2e`** script — `tauri build --debug --no-bundle --config src-tauri/tauri.e2e.conf.json` (Tauri deep-merges the overlay).
- **CI** and the **local E2E docs** now build via `pnpm build:e2e`.

Production/release builds are untouched (`withGlobalTauri: false` stays in `tauri.conf.json`). Only the debug E2E binary gets the bridge — a test artifact that is never shipped. The release **Smoke E2E** job is unaffected (its `smoke.spec` doesn't touch `__TAURI__`).

## Validation

Locally, `pnpm build:e2e` parses the merged config and builds cleanly (the `--config` path resolves, the overlay merges). The real proof is this PR's own **E2E job** going green.

Fixes the red E2E on master; #156 will go green once rebased on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)