### PR TITLE
feat(ui): About dialog — version + manual update check

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -315,5 +315,12 @@
   "update_available_title": "New version available",
   "update_available_body": "Clavix {version} is available (you're on {current}).",
   "update_action_view": "View release",
-  "update_action_dismiss": "Dismiss"
+  "update_action_dismiss": "Dismiss",
+  "about_label": "About",
+  "about_title": "About Clavix",
+  "about_version": "Version {version}",
+  "about_check_updates": "Check for updates",
+  "about_checking": "Checking…",
+  "about_up_to_date": "You're on the latest version.",
+  "about_check_failed": "Couldn't check — are you offline?"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -315,5 +315,12 @@
   "update_available_title": "Nouvelle version disponible",
   "update_available_body": "Clavix {version} est disponible (vous utilisez la {current}).",
   "update_action_view": "Voir la version",
-  "update_action_dismiss": "Ignorer"
+  "update_action_dismiss": "Ignorer",
+  "about_label": "À propos",
+  "about_title": "À propos de Clavix",
+  "about_version": "Version {version}",
+  "about_check_updates": "Vérifier les mises à jour",
+  "about_checking": "Vérification…",
+  "about_up_to_date": "Vous utilisez la dernière version.",
+  "about_check_failed": "Vérification impossible — êtes-vous hors ligne ?"
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "clavix"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes 0.8.4",
  "argon2",

--- a/src-tauri/src/commands/update.rs
+++ b/src-tauri/src/commands/update.rs
@@ -9,3 +9,10 @@ use crate::update::{self, UpdateInfo};
 pub async fn check_for_update() -> Result<UpdateInfo> {
     update::check_for_update().await
 }
+
+/// This build's version (`CARGO_PKG_VERSION`). Offline, no session — lets the
+/// About dialog show the running version instantly without a network round-trip.
+#[tauri::command]
+pub fn app_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -164,6 +164,7 @@ pub fn run() {
             commands::tray::set_tray_locale,
             commands::import::parse_kdbx,
             commands::update::check_for_update,
+            commands::update::app_version,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/lib/AboutDialog.svelte
+++ b/src/lib/AboutDialog.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import { openUrl } from "@tauri-apps/plugin-opener";
+  import * as m from "$lib/paraglide/messages";
+  import { api } from "./api";
+  import Icon from "./Icon.svelte";
+  import type { Locale, UpdateInfo } from "./types";
+
+  type Props = {
+    currentLocale: Locale;
+  };
+
+  let { currentLocale }: Props = $props();
+
+  let dialog = $state<HTMLDialogElement | null>(null);
+  let version = $state("");
+  let checking = $state(false);
+  // null = not checked yet this session; otherwise the last verdict.
+  let result = $state<UpdateInfo | null>(null);
+  let failed = $state(false);
+
+  async function check() {
+    checking = true;
+    failed = false;
+    result = null;
+    try {
+      result = await api.checkForUpdate();
+    } catch {
+      // Offline / rate-limited / GitHub down — a manual check shouldn't error
+      // loudly, just report it couldn't reach the server.
+      failed = true;
+    } finally {
+      checking = false;
+    }
+  }
+
+  export async function open() {
+    checking = false;
+    result = null;
+    failed = false;
+    dialog?.showModal();
+    try {
+      version = await api.appVersion();
+    } catch {
+      version = "";
+    }
+  }
+
+  function close() {
+    dialog?.close();
+  }
+
+  async function openReleasePage() {
+    if (result) await openUrl(result.url);
+  }
+</script>
+
+<dialog bind:this={dialog} class="stats-dialog about-dialog">
+  {#key currentLocale}
+    <header class="stats-header">
+      <h2>{m.about_title()}</h2>
+      <button type="button" class="secondary small" onclick={close} aria-label={m.action_close()}>
+        ✕
+      </button>
+    </header>
+
+    <div class="about-body">
+      <p class="about-version">{m.about_version({ version: version || "…" })}</p>
+
+      <div class="about-actions">
+        <button type="button" onclick={check} disabled={checking}>
+          {checking ? m.about_checking() : m.about_check_updates()}
+        </button>
+        {#if checking}
+          <span class="about-spinner" aria-hidden="true"></span>
+        {/if}
+      </div>
+
+      {#if failed}
+        <p class="about-status about-status--warn">{m.about_check_failed()}</p>
+      {:else if result?.updateAvailable}
+        <div class="about-status about-status--update">
+          <span>{m.update_available_body({ version: result.latest, current: result.current })}</span>
+          <button type="button" class="primary small" onclick={openReleasePage}>
+            <Icon name="download" size={14} />
+            {m.update_action_view()}
+          </button>
+        </div>
+      {:else if result}
+        <p class="about-status about-status--ok">✔ {m.about_up_to_date()}</p>
+      {/if}
+    </div>
+  {/key}
+</dialog>
+
+<style>
+  .about-dialog {
+    max-width: 24rem;
+  }
+
+  .about-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    margin-top: 0.4rem;
+  }
+
+  .about-version {
+    font-size: 0.95rem;
+    font-weight: 500;
+    margin: 0;
+  }
+
+  .about-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+  }
+
+  .about-spinner {
+    width: 1.05rem;
+    height: 1.05rem;
+    border: 2px solid #c7d2fe;
+    border-top-color: #396cd8;
+    border-radius: 50%;
+    animation: about-spin 0.7s linear infinite;
+    flex: none;
+  }
+
+  @keyframes about-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .about-status {
+    margin: 0;
+    font-size: 0.85rem;
+  }
+
+  .about-status--ok {
+    color: #15803d;
+  }
+
+  .about-status--warn {
+    color: #b45309;
+  }
+
+  .about-status--update {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .about-status--ok {
+      color: #4ade80;
+    }
+    .about-status--warn {
+      color: #fbbf24;
+    }
+  }
+
+  :global(:root.force-dark) .about-status--ok {
+    color: #4ade80;
+  }
+  :global(:root.force-dark) .about-status--warn {
+    color: #fbbf24;
+  }
+</style>

--- a/src/lib/Icon.svelte
+++ b/src/lib/Icon.svelte
@@ -29,6 +29,7 @@
     | "dice" // generator
     | "shield" // audit
     | "info" // stats / infos
+    | "arrow-up-circle" // about / check for updates
     | "edit" // edit cipher
     | "eye" // reveal field
     | "eye-off" // hide field
@@ -147,6 +148,10 @@
     <circle cx="12" cy="12" r="10" />
     <line x1="12" y1="16" x2="12" y2="12" />
     <line x1="12" y1="8" x2="12.01" y2="8" />
+  {:else if name === "arrow-up-circle"}
+    <circle cx="12" cy="12" r="10" />
+    <path d="M8 12l4-4 4 4" />
+    <line x1="12" y1="16" x2="12" y2="8" />
   {:else if name === "edit"}
     <path d="M12 20h9" />
     <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />

--- a/src/lib/Toolbar.svelte
+++ b/src/lib/Toolbar.svelte
@@ -22,6 +22,7 @@
     onOpenGenerator: () => void;
     onOpenAudit: () => void;
     onOpenStats: () => void;
+    onOpenAbout: () => void;
   };
 
   let {
@@ -38,6 +39,7 @@
     onOpenGenerator,
     onOpenAudit,
     onOpenStats,
+    onOpenAbout,
   }: Props = $props();
 
   // `now` ticks once a minute so the "il y a N min" text and the
@@ -172,6 +174,15 @@
       aria-label={m.tree_infos_label()}
     >
       <Icon name="info" size={18} />
+    </button>
+    <button
+      type="button"
+      class="tb-btn"
+      onclick={onOpenAbout}
+      title={m.about_label()}
+      aria-label={m.about_label()}
+    >
+      <Icon name="arrow-up-circle" size={18} />
     </button>
   </div>
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -194,6 +194,9 @@ export const api = {
   /** Ask GitHub (from Rust — the CSP blocks the WebView from reaching it)
       whether a newer Clavix has been published. */
   checkForUpdate: () => invoke<UpdateInfo>("check_for_update"),
+
+  /** This build's version, straight from Rust (offline, no network). */
+  appVersion: () => invoke<string>("app_version"),
 };
 
 /// Flat entry shape returned by `parse_kdbx` — mirrors the CSV

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,6 +13,7 @@
   import GeneratorDialog from "$lib/GeneratorDialog.svelte";
   import StatsDialog from "$lib/StatsDialog.svelte";
   import AuditDialog from "$lib/AuditDialog.svelte";
+  import AboutDialog from "$lib/AboutDialog.svelte";
   import UpdateBanner from "$lib/UpdateBanner.svelte";
   import { ClipboardController, type ClipboardVariant } from "$lib/clipboard.svelte";
   import { DragController } from "$lib/drag.svelte";
@@ -43,6 +44,7 @@
   let searchInput: HTMLInputElement | null = null;
   let statsDialog = $state<{ open: () => Promise<void> } | null>(null);
   let auditDialog = $state<{ open: () => void } | null>(null);
+  let aboutDialog = $state<{ open: () => Promise<void> } | null>(null);
   let generatorDialog = $state<{ open: () => void } | null>(null);
   let importOpen = $state(false);
   let exportOpen = $state(false);
@@ -398,6 +400,7 @@
         onOpenGenerator={() => generatorDialog?.open()}
         onOpenAudit={() => auditDialog?.open()}
         onOpenStats={() => statsDialog?.open()}
+        onOpenAbout={() => aboutDialog?.open()}
       />
 
       {#if vault.summary}
@@ -585,6 +588,8 @@
   currentLocale={prefs.currentLocale}
   onJumpToCipher={(id) => vault.jumpToCipher(id)}
 />
+
+<AboutDialog bind:this={aboutDialog} currentLocale={prefs.currentLocale} />
 
 {#key prefs.currentLocale}
   <CipherEditor


### PR DESCRIPTION
## What

You asked for a way to see the running version and check for updates on demand. This adds a toolbar button (in the tools group, ↑-in-circle icon) that opens an **"À propos"** dialog:

- **Shows the current version** — fetched from a new `app_version` command (`CARGO_PKG_VERSION`), so it appears instantly and works offline.
- **"Vérifier les mises à jour"** button — reuses the existing `check_for_update` (the outbound request runs in Rust so the CSP-locked WebView never touches GitHub). Reports one of:
  - ✔ up to date,
  - a newer version available, with a **"Voir la version"** link opening the release page in the system browser,
  - a soft "couldn't check — offline?" on failure (never a hard error).

Complements the automatic startup banner (#156) with a manual, always-available path.

## Changes

- `src-tauri/src/commands/update.rs` — `app_version` command.
- `src/lib/AboutDialog.svelte` — the dialog (mirrors the AuditDialog shell + spinner).
- `src/lib/Toolbar.svelte` + `Icon.svelte` — new `arrow-up-circle` button.
- `src/lib/{api,+page}.ts/.svelte` — wiring; fr/en strings.

### Drive-by fix
`Cargo.lock`'s `clavix` entry bumped 0.4.0 → 0.5.0. release-please updated `Cargo.toml` but not the lock, so `cargo --locked` couldn't build from a clean checkout (master CI only stayed green because an earlier non-locked step regenerated it). One line.

## Verification

- `cargo clippy --all-targets --locked -- -D warnings` — clean
- ts-rs bindings drift-check — clean (no boundary struct changed)
- `pnpm check` — 0 errors · `pnpm test` — 126 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)