### PR TITLE
feat(ui): link clavix.org from the About dialog

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -322,5 +322,6 @@
   "about_check_updates": "Check for updates",
   "about_checking": "Checking…",
   "about_up_to_date": "You're on the latest version.",
-  "about_check_failed": "Couldn't check — are you offline?"
+  "about_check_failed": "Couldn't check — are you offline?",
+  "about_website": "Clavix website"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -322,5 +322,6 @@
   "about_check_updates": "Vérifier les mises à jour",
   "about_checking": "Vérification…",
   "about_up_to_date": "Vous utilisez la dernière version.",
-  "about_check_failed": "Vérification impossible — êtes-vous hors ligne ?"
+  "about_check_failed": "Vérification impossible — êtes-vous hors ligne ?",
+  "about_website": "Site web de Clavix"
 }

--- a/src/lib/AboutDialog.svelte
+++ b/src/lib/AboutDialog.svelte
@@ -52,6 +52,10 @@
   async function openReleasePage() {
     if (result) await openUrl(result.url);
   }
+
+  async function openWebsite() {
+    await openUrl("https://clavix.org");
+  }
 </script>
 
 <dialog bind:this={dialog} class="stats-dialog about-dialog">
@@ -65,6 +69,18 @@
 
     <div class="about-body">
       <p class="about-version">{m.about_version({ version: version || "…" })}</p>
+
+      <p class="about-website-row">
+        <button
+          type="button"
+          class="about-link"
+          onclick={openWebsite}
+          title={m.about_website()}
+          aria-label={m.about_website()}
+        >
+          clavix.org
+        </button>
+      </p>
 
       <div class="about-actions">
         <button type="button" onclick={check} disabled={checking}>
@@ -108,6 +124,41 @@
     font-size: 0.95rem;
     font-weight: 500;
     margin: 0;
+  }
+
+  .about-website-row {
+    margin: -0.4rem 0 0;
+  }
+
+  .about-link {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    font-size: 0.85rem;
+    color: #2563eb;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .about-link:hover {
+    color: #1d4ed8;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .about-link {
+      color: #60a5fa;
+    }
+    .about-link:hover {
+      color: #93c5fd;
+    }
+  }
+
+  :global(:root.force-dark) .about-link {
+    color: #60a5fa;
+  }
+  :global(:root.force-dark) .about-link:hover {
+    color: #93c5fd;
   }
 
   .about-actions {


### PR DESCRIPTION
Adds a **clavix.org** link under the version in the "À propos" dialog. It opens the project site in the system browser (`openUrl`) — never navigates the CSP-locked WebView.

Frontend-only (AboutDialog + fr/en strings). `pnpm check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)