### PR TITLE
fix(import): widen preview, fix sticky-header overlap, clarify oversized notes

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -139,7 +139,7 @@
   "import_skipped": "{count} not imported (duplicates or unchecked).",
   "import_select_all": "Select all",
   "import_selected": "{selected} of {total} selected",
-  "import_notes_too_long": "{count} entry/entries have notes too long for the server (limit: 10,000 characters once encrypted, i.e. about 7,400 typed characters — a PGP key exceeds it). They will be rejected on import. On Vaultwarden, INCREASE_NOTE_SIZE_LIMIT=true raises the limit to 100,000.",
+  "import_notes_too_long": "{count} entry/entries have very long notes. They stay selected and will be attempted: a server with the default limit (10,000 characters once encrypted, i.e. about 7,400 typed — a PGP key exceeds it) will reject them, but on Vaultwarden with INCREASE_NOTE_SIZE_LIMIT=true (limit raised to 100,000) they'll import fine.",
   "import_failures_heading": "Entries rejected by the server:",
   "export_label": "Export (Bitwarden CSV)",
   "export_title": "Export the vault",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -139,7 +139,7 @@
   "import_skipped": "{count} non importée(s) (doublons ou décochées).",
   "import_select_all": "Tout sélectionner",
   "import_selected": "{selected} / {total} sélectionnée(s)",
-  "import_notes_too_long": "{count} entrée(s) ont des notes trop longues pour le serveur (limite : 10 000 caractères une fois chiffrés, soit environ 7 400 caractères saisis — une clé PGP dépasse ce seuil). Elles seront refusées à l'import. Sur Vaultwarden, INCREASE_NOTE_SIZE_LIMIT=true relève la limite à 100 000.",
+  "import_notes_too_long": "{count} entrée(s) ont des notes très longues. Elles restent cochées et seront tentées à l'import : un serveur avec la limite par défaut (10 000 caractères une fois chiffrés, soit environ 7 400 saisis — une clé PGP dépasse ce seuil) les refusera, mais sur Vaultwarden avec INCREASE_NOTE_SIZE_LIMIT=true (limite portée à 100 000) elles passeront.",
   "import_failures_heading": "Entrées refusées par le serveur :",
   "export_label": "Exporter (CSV Bitwarden)",
   "export_title": "Exporter le coffre",

--- a/src/lib/ImportDialog.svelte
+++ b/src/lib/ImportDialog.svelte
@@ -535,7 +535,7 @@
     background: #fff;
     border-radius: 10px;
     padding: 1.1rem 1.4rem;
-    width: min(640px, 96vw);
+    width: min(880px, 96vw);
     max-height: 92vh;
     overflow-y: auto;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
@@ -670,17 +670,26 @@
 
   table {
     width: 100%;
-    border-collapse: collapse;
+    /* `separate` (not `collapse`) so the sticky header keeps its own
+       border while rows scroll under it — with `collapse` the shared
+       border belongs to the cells and scrolls away, letting row text
+       bleed over the header. */
+    border-collapse: separate;
+    border-spacing: 0;
     font-size: 0.82rem;
   }
 
   th {
     position: sticky;
     top: 0;
+    /* Sit above the scrolling body so rows never paint over the header. */
+    z-index: 2;
     background: #f3f4f6;
     padding: 0.35rem 0.5rem;
     text-align: left;
-    border-bottom: 1px solid #d0d0d0;
+    /* box-shadow, not border-bottom: a sticky element's own border can
+       still be overpainted by scrolling cells; an inset shadow can't. */
+    box-shadow: inset 0 -1px 0 #d0d0d0;
   }
 
   td {
@@ -689,7 +698,7 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 180px;
+    max-width: 240px;
   }
 
   .url-cell {


### PR DESCRIPTION
Polissage du dialogue d'import sélectionnable (#162), suite au test utilisateur.

## Corrections
1. **Largeur** — dialogue élargi 640→880px : les colonnes URL et Dossier ne sont plus coupées.
2. **Cases impossibles à re-cocher quand tout est décoché** — cause réelle identifiée par test headless : l'en-tête `sticky` sans `z-index` (+ `border-collapse: collapse`) laissait les lignes déborder sur lui, et un vrai clic souris tombait sur l'en-tête au lieu de la case. Corrigé.
3. **Chevauchement du texte sur l'en-tête au défilement** — même racine : `border-collapse: separate` + `z-index: 2` + séparateur en `box-shadow` inset ; l'en-tête reste franchement au-dessus du corps.
4. **Notes trop longues (clé PGP)** — ces entrées étaient déjà tentées à l'import (jamais exclues) ; seul le message mentait. Reformulé en conditionnel : refusées par un serveur à la limite par défaut, mais importées avec `INCREASE_NOTE_SIZE_LIMIT=true` (limite 100 000).

## Vérifications
- `pnpm run check` → 0 erreur
- `pnpm run test` → 126 tests OK
- Vérifié visuellement via un harnais de test headless (340 lignes) : toggle individuel, sélection/désélection globale, en-tête propre au scroll, colonnes complètes — harnais supprimé après usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2sx29J7nerEhLwmgW7ESL