### PR TITLE
fix(import): stop the preview's horizontal scrollbar overlapping the last checkbox

### DIFF
--- a/src/lib/ImportDialog.svelte
+++ b/src/lib/ImportDialog.svelte
@@ -651,6 +651,10 @@
   .import-preview {
     max-height: 280px;
     overflow-y: auto;
+    /* No horizontal scrollbar: cells already truncate with an ellipsis,
+       and a bottom scrollbar overlapped the last row's checkbox, making
+       it a fight to tick. */
+    overflow-x: hidden;
     border: 1px solid #e6e6e6;
     border-radius: 6px;
     margin: 0 0 0.4rem;
@@ -670,6 +674,10 @@
 
   table {
     width: 100%;
+    /* Fixed layout so columns share the container width and long values
+       ellipsis-truncate instead of widening the table past its box (which
+       forced a horizontal scrollbar over the last checkbox). */
+    table-layout: fixed;
     /* `separate` (not `collapse`) so the sticky header keeps its own
        border while rows scroll under it — with `collapse` the shared
        border belongs to the cells and scrolls away, letting row text
@@ -698,7 +706,6 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 240px;
   }
 
   .url-cell {


### PR DESCRIPTION
Suite du polissage du dialogue d'import — retour utilisateur : difficile de cocher le **dernier élément** de la liste, car la barre de scroll horizontale apparaît et chevauche la case.

## Cause
Les titres/URL longs élargissaient le tableau au-delà de son conteneur → une barre de scroll horizontale s'affichait en bas de l'aperçu, pile sur la case de la dernière ligne.

## Correction
- `table-layout: fixed` : les colonnes se partagent la largeur du conteneur et les valeurs longues tronquent en `…` (comme le faisaient déjà les autres cellules).
- `overflow-x: hidden` sur la zone de scroll → il ne reste que la barre verticale.

## Vérification (headless)
Liste de 12 lignes défilée tout en bas :
- `hScroll=false` (aucun débordement horizontal)
- hit-test au centre de la dernière case → `INPUT.checkbox` (la case reçoit bien le clic)
- `pnpm run check` → 0 erreur ; `pnpm run test` → 126 tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2sx29J7nerEhLwmgW7ESL