### PR TITLE
fix(sync): send Bitwarden-Client-Version header so SSH keys sync

### DIFF
--- a/src-tauri/src/api.rs
+++ b/src-tauri/src/api.rs
@@ -1,3 +1,4 @@
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
 use serde_json::json;
 use url::Url;
@@ -22,8 +23,25 @@ pub struct DeviceInfo {
 impl VaultwardenClient {
     pub fn new(base_url: &str) -> Result<Self> {
         let base_url = normalize_base_url(base_url)?;
+
+        // Vaultwarden strips SSH-key ciphers (type 5) from the /sync
+        // response unless the client advertises a version >= 2024.12.0
+        // through this header — see vaultwarden `src/api/core/ciphers.rs`
+        // (`show_ssh_keys`) and `ClientVersion` in `src/auth.rs`. Absent
+        // the header the server treats us as a pre-SSH client and the keys
+        // silently never reach us. The value only has to parse as semver
+        // and clear the >=2024.12.0 gate; we pin the minimum rather than a
+        // higher one to avoid opting into any newer version-gated wire
+        // behaviour we don't yet handle.
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            HeaderName::from_static("bitwarden-client-version"),
+            HeaderValue::from_static("2024.12.0"),
+        );
+
         let http = Client::builder()
             .user_agent(concat!("Clavix/", env!("CARGO_PKG_VERSION")))
+            .default_headers(headers)
             .build()?;
         Ok(Self { http, base_url })
     }


### PR DESCRIPTION
## Problème

Les items « Clé SSH » (type 5) n'apparaissaient jamais dans Clavix (ni dans la liste, ni dans l'agent SSH), alors que le coffre Vaultwarden en contient et que le serveur est correctement configuré (`EXPERIMENTAL_CLIENT_FEATURE_FLAGS=ssh-key-vault-item,...`).

## Cause (confirmée dans le code Vaultwarden)

`src/api/core/ciphers.rs` :

```rust
let show_ssh_keys = client_version.map_or(false, |v| ">=2024.12.0".matches(&v));
if !show_ssh_keys {
    ciphers.retain(|c| c.atype != 5);   // clés SSH retirées du /sync
}
```

La version client est lue dans l'en-tête **`Bitwarden-Client-Version`** (`ClientVersion`, `src/auth.rs`). Clavix ne l'envoyait pas → `client_version = None` → le serveur retirait tous les ciphers de type 5 de la réponse de sync. Les clés n'atteignaient donc jamais le client (elles n'étaient pas mal typées : elles étaient **absentes**).

## Correctif

Ajout de `Bitwarden-Client-Version: 2024.12.0` comme en-tête par défaut du client HTTP (`src-tauri/src/api.rs`). On épingle le minimum qui débloque le gate plutôt qu'une version plus récente, pour ne pas opter dans d'autres comportements réseau liés aux versions que Clavix ne parse pas encore.

## Effet attendu

Après cette version, un **Synchroniser** fait apparaître les clés SSH sous le filtre « Clé SSH », et l'agent SSH peut les charger.

## Tests

- `cargo build` : OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)