### PR TITLE
docs: how to point ssh at the agent persistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,42 @@ destruction.
 
 ---
 
+## Using the SSH agent persistently
+
+The agent listens on `$XDG_RUNTIME_DIR/clavix/agent.sock` — usually
+`/run/user/<uid>/clavix/agent.sock`. The *Infos* dialog shows the exact
+path. Nothing points to it by default, so set it up once:
+
+**For `ssh`, `git`, and GUI apps** — add a drop-in to your SSH config
+(`~/.ssh/config`, or a file included from it):
+
+```
+Host *
+    IdentityAgent /run/user/%i/clavix/agent.sock
+```
+
+`%i` expands to your UID. This is the more robust of the two: it also
+covers GUI apps launched from the desktop menu, which don't read your
+shell startup files.
+
+**For everything else** — export the variable in `~/.bashrc` (or
+`~/.zshrc`):
+
+```sh
+export SSH_AUTH_SOCK="/run/user/$(id -u)/clavix/agent.sock"
+```
+
+Doing both is a good idea. `ssh-add` in particular ignores
+`~/.ssh/config` entirely and only reads `$SSH_AUTH_SOCK`, so without the
+export `ssh-add -l` reports "The agent has no identities" even when
+`ssh` is happily using Clavix.
+
+The socket lives under `/run`, so it disappears on reboot and is
+recreated when Clavix starts. A `Connection refused` on that path means
+Clavix isn't running, not that your config is wrong.
+
+---
+
 ## Why this project
 
 The official Bitwarden client (Electron) has a dated UX and does not


### PR DESCRIPTION
The agent socket path is discoverable in the Infos dialog, but nothing points to it by default and the README never said how to wire it up.

Documents both halves, because neither alone is enough: IdentityAgent in ~/.ssh/config covers ssh/git and GUI apps launched from the desktop menu (which don't read shell startup files), while the SSH_AUTH_SOCK export covers ssh-add, the one SSH client that ignores ~/.ssh/config entirely and reports "The agent has no identities" without it.

## What does this PR do?

<!-- Summary in one or two sentences. Link related issues. -->

Closes #<!-- issue number, if applicable -->

## Why?

<!-- The user problem or design rationale. Keep it short. -->

## How has this been tested?

<!-- Describe manual tests, new unit tests, etc. -->

## Checklist

- [ ] `pnpm check` passes locally
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --all-targets -- -D warnings` passes
- [ ] Any new user-visible string has been added to both
      `messages/fr.json` and `messages/en.json`
- [ ] `DISCLAIMER.md` / `README.md` / `CHANGELOG.md` updated if
      user-facing behaviour changed
- [ ] I acknowledge that my contribution is licensed under GPL-3.0-or-later
