### PR TITLE
feat(ssh-agent): show full key fingerprints

### DIFF
--- a/src/lib/StatsDialog.svelte
+++ b/src/lib/StatsDialog.svelte
@@ -132,14 +132,6 @@
     }
   }
 
-  // Truncate a SHA256:abcdef… fingerprint for compact display while
-  // keeping enough characters to spot the right key at a glance.
-  // Full fingerprint is still shown via the title attribute on hover.
-  function shortFingerprint(fp: string): string {
-    if (fp.length <= 24) return fp;
-    return fp.slice(0, 17) + "…" + fp.slice(-4);
-  }
-
   async function toggleSshAgent() {
     sshAgentBusy = true;
     sshAgentError = null;
@@ -393,9 +385,11 @@
           <li class="ssh-agent-key">
             <span class="ssh-agent-key-comment">{key.comment || "—"}</span>
             <span class="ssh-agent-key-algo">{key.algorithm}</span>
-            <code class="ssh-agent-key-fp" title={key.fingerprint}>
-              {shortFingerprint(key.fingerprint)}
-            </code>
+            <!-- Shown in full: the columns now hug their content, which
+                 leaves room for the whole fingerprint. CSS ellipsises it
+                 if the dialog is ever too narrow, and `title` keeps the
+                 full value reachable either way. -->
+            <code class="ssh-agent-key-fp" title={key.fingerprint}>{key.fingerprint}</code>
           </li>
         {/each}
       </ul>

--- a/src/styles/dialogs.css
+++ b/src/styles/dialogs.css
@@ -182,6 +182,13 @@
   font-family: ui-monospace, monospace;
   font-size: 0.74rem;
   color: #444;
+  /* The full fingerprint is rendered now. It fits at the dialog's normal
+     width; on a narrow window the track shrinks below its content and
+     the ellipsis takes over, with `title` still carrying the full value.
+     Without this the unbreakable string would overflow the row. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .ssh-agent-skipped-list {


### PR DESCRIPTION
## Why

`shortFingerprint` dated from the 480px dialog, where the fingerprint column was squeezed. After #198 and #200 the columns hug their content, leaving plenty of room for all 51 characters.

More to the point, a truncated fingerprint is the one form that can't do a fingerprint's job. `SHA256:akV5w03vG8…RYFs` cannot be compared against `ssh-add -l` output, or against what GitHub shows on the key settings page — and comparing is the only reason anyone reads one.

## What

The JS helper is **deleted** rather than left unused; the full value is rendered directly.

CSS handles the narrow case instead: the track shrinks below its content and the ellipsis takes over, with `title` carrying the full value either way. Without the overflow rules the unbreakable 51-character string would spill out of the row.

## Verification

Rendered these exact rules with real-length fingerprints at both the normal dialog width and 420px, and confirmed with the reporter before committing.

- `pnpm run check` — 1115 files, 0 errors
- `pnpm vitest run` — 135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SffAkhYYDgKbsJFNuqNMvY