### PR TITLE
feat(ssh-agent): show the full fingerprint in the signing prompt

### DIFF
--- a/src/lib/SshConfirmDialog.svelte
+++ b/src/lib/SshConfirmDialog.svelte
@@ -62,10 +62,6 @@
     if (next) show(next);
   }
 
-  function shortFp(fp: string): string {
-    return fp.length <= 24 ? fp : fp.slice(0, 17) + "…" + fp.slice(-4);
-  }
-
   // "git (pid 4321)" / "pid 4321" when the name is unavailable (macOS has
   // no /proc) / null when the peer couldn't be identified at all.
   const callerLabel = $derived.by(() => {
@@ -96,7 +92,13 @@
         <span class="ssh-confirm-algo">{current.algorithm}</span>
       </dd>
       <dt>{m.ssh_confirm_fingerprint()}</dt>
-      <dd><code title={current.fingerprint}>{shortFp(current.fingerprint)}</code></dd>
+      <!-- Full value: this is the prompt where the fingerprint matters
+           most — approving a signature means recognising the key, and a
+           truncated fingerprint can't be compared against `ssh-add -l`
+           or the one shown by the server. `code` already carries
+           `word-break: break-all`, so a narrow window wraps it rather
+           than overflowing. -->
+      <dd><code title={current.fingerprint}>{current.fingerprint}</code></dd>
       <dt>{m.ssh_confirm_caller_label()}</dt>
       <dd>
         {#if callerLabel}
@@ -120,7 +122,11 @@
 
 <style>
   .ssh-confirm-dialog {
-    max-width: 26rem;
+    /* 26rem left the fingerprint field about 276px against the ~386px a
+       full SHA256 fingerprint needs, which is why it used to be
+       truncated. Widened to fit it on one line; the `min` keeps the
+       dialog inside a narrow viewport. */
+    max-width: min(35rem, calc(100vw - 2rem));
     border: none;
     border-radius: 10px;
     padding: 1.25rem 1.4rem;


### PR DESCRIPTION
## Why

Same reasoning as the key list in #202, applied to the dialog where it matters most. Approving a signature means **recognising the key** — and `SHA256:akV5w03vG8…RYFs` can't be compared against `ssh-add -l` or against the fingerprint the server shows.

## What

The dialog's `26rem` left the fingerprint field about **276px** against the **~386px** a full SHA256 fingerprint needs — which is why it was truncated in the first place. Widened to `min(35rem, 100vw - 2rem)` so it fits on one line while still respecting a narrow viewport.

`code` already carries `word-break: break-all`, so the worst case wraps rather than overflowing. The `shortFp` helper is deleted rather than left unused.

## Verification

Rendered the real dialog styles with a real-length fingerprint at both 35rem and 380px, and confirmed with the reporter before committing.

- `pnpm run check` — 1115 files, 0 errors

## Side note

This screenshot also confirmed the caller-identity feature from #194 working in the real app for the first time — the prompt showed `ssh (pid 558783)`. It had shipped untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SffAkhYYDgKbsJFNuqNMvY