### PR TITLE
fix(import): back off instead of hammering a server that says no

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -162,6 +162,8 @@
   "import_done": "Done: {created} created, {failed} failed.",
   "import_already_present": "{count} entry/entries are already in the vault (same name and username): they will be skipped, and your edits kept.",
   "import_skipped": "{count} not imported (duplicates or unchecked).",
+  "import_aborted_rate_limited": "Import stopped: the server is rate-limiting and did not recover after several retries. {remaining} item(s) were not attempted. Try again later — items already created won't be duplicated.",
+  "import_aborted_blocked": "Import stopped: the server (or a web application firewall in front of it) refused the connection. {remaining} item(s) were not attempted. Check whether your IP has been banned, then try again — items already created won't be duplicated.",
   "import_select_all": "Select all",
   "import_selected": "{selected} of {total} selected",
   "import_notes_too_long": "{count} entry/entries have very long notes. They stay selected and will be attempted: a server with the default limit (10,000 characters once encrypted, i.e. about 7,400 typed — a PGP key exceeds it) will reject them, but on Vaultwarden with INCREASE_NOTE_SIZE_LIMIT=true (limit raised to 100,000) they'll import fine.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -162,6 +162,8 @@
   "import_done": "Terminé : {created} créé(s), {failed} échec(s).",
   "import_already_present": "{count} entrée(s) sont déjà dans le coffre (même nom et même identifiant) : elles seront ignorées, vos modifications sont préservées.",
   "import_skipped": "{count} non importée(s) (doublons ou décochées).",
+  "import_aborted_rate_limited": "Import interrompu : le serveur limite le débit et n'a pas repris la main après plusieurs tentatives. {remaining} item(s) n'ont pas été tentés. Réessayez plus tard — les items déjà créés ne seront pas dupliqués.",
+  "import_aborted_blocked": "Import interrompu : le serveur (ou un pare-feu applicatif devant lui) a refusé la connexion. {remaining} item(s) n'ont pas été tentés. Vérifiez si votre adresse IP a été bannie, puis réessayez — les items déjà créés ne seront pas dupliqués.",
   "import_select_all": "Tout sélectionner",
   "import_selected": "{selected} / {total} sélectionnée(s)",
   "import_notes_too_long": "{count} entrée(s) ont des notes très longues. Elles restent cochées et seront tentées à l'import : un serveur avec la limite par défaut (10 000 caractères une fois chiffrés, soit environ 7 400 saisis — une clé PGP dépasse ce seuil) les refusera, mais sur Vaultwarden avec INCREASE_NOTE_SIZE_LIMIT=true (limite portée à 100 000) elles passeront.",

--- a/src/lib/ImportDialog.svelte
+++ b/src/lib/ImportDialog.svelte
@@ -8,6 +8,7 @@
   import {
     EMPTY_EDITOR_INITIAL,
     type CipherSummary,
+    type EditorPayload,
     type CollectionSummary,
     type FolderSummary,
     type OrganizationSummary,
@@ -58,12 +59,39 @@
   // note vanished with no way to tell which one it was.
   let failures = $state<{ title: string; username: string; message: string }[]>([]);
   let skippedCount = $state(0);
+  // Set when the run stopped early because the server pushed back
+  // (rate limit exhausted, or a proxy/WAF refusing us outright). The
+  // remaining entries were never attempted — see `startImport`.
+  let abortedReason = $state<"rate_limited" | "blocked" | null>(null);
   // KDBX path: we hold the picked file until the user types the
   // master password, then call `parse_kdbx` over IPC. The CSV path
   // ignores all of these.
   let pendingKdbxFile = $state<File | null>(null);
   let kdbxPassword = $state("");
   let kdbxParsing = $state(false);
+
+  // An import is the one place Clavix issues hundreds of writes back to
+  // back, and a self-hosted server usually sits behind something that
+  // reacts to that. Left unthrottled, a 1100-item import tripped
+  // Vaultwarden's own rate limiter, whose 429s then tripped the WAF in
+  // front of it, which banned the client for an hour — and the loop kept
+  // firing another 1100 requests into the ban.
+  //
+  // Hence: space the writes out, back off when told to, and stop rather
+  // than hammer a server that is refusing us.
+  const THROTTLE_MS = 60;
+  const MAX_RATE_LIMIT_RETRIES = 5;
+  const BASE_BACKOFF_MS = 1000;
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  /** HTTP status behind a Tauri error, or null if it wasn't an HTTP one. */
+  function httpStatusOf(e: unknown): number | null {
+    const err = e as { code?: string; data?: { status?: unknown } };
+    if (err?.code !== "http_status") return null;
+    const status = Number(err.data?.status);
+    return Number.isFinite(status) ? status : null;
+  }
 
   const existingIds = $derived(
     new Set(existing.map((c) => importIdentity(c.name, c.username ?? ""))),
@@ -125,6 +153,7 @@
       failures = [];
       skippedCount = 0;
       plannedCount = 0;
+      abortedReason = null;
       excluded = new Set();
       pendingKdbxFile = null;
       kdbxPassword = "";
@@ -223,6 +252,9 @@
     failedCount = 0;
     lastError = null;
     failures = [];
+    // Must be cleared here too: without it a second run would break out
+    // of the loop on its first iteration, importing nothing.
+    abortedReason = null;
     plannedCount = toImport.length;
     // Everything parsed but left out of this run: duplicates plus unchecked rows.
     skippedCount = entries.length - toImport.length;
@@ -250,7 +282,10 @@
           folderId = known ?? null;
         }
 
-        await api.createCipher({
+        // Annotated because hoisting the literal out of the call site
+        // loses the contextual typing that narrowed `cipherType` to
+        // `CipherKind`.
+        const payload: EditorPayload = {
           ...EMPTY_EDITOR_INITIAL,
           cipherType: 1,
           name: entry.title || "(sans nom)",
@@ -262,8 +297,33 @@
           password: entry.password,
           uris: entry.url ? [entry.url] : [],
           totp: entry.totp,
-        });
-        createdCount += 1;
+        };
+
+        // Retry only what retrying can fix. A 429 means "slow down", so
+        // wait longer each time. A 403 means something in front of the
+        // server has decided against us — retrying is what turns a
+        // refusal into a ban, so stop immediately and say so.
+        let attempt = 0;
+        for (;;) {
+          try {
+            await api.createCipher(payload);
+            createdCount += 1;
+            break;
+          } catch (e) {
+            const status = httpStatusOf(e);
+            if (status === 429 && attempt < MAX_RATE_LIMIT_RETRIES) {
+              attempt += 1;
+              await sleep(BASE_BACKOFF_MS * 2 ** (attempt - 1));
+              continue;
+            }
+            if (status === 429) {
+              abortedReason = "rate_limited";
+            } else if (status === 403) {
+              abortedReason = "blocked";
+            }
+            throw e;
+          }
+        }
       } catch (e) {
         failedCount += 1;
         lastError = (e as Error).message ?? String(e);
@@ -274,6 +334,12 @@
         });
       }
       progress += 1;
+
+      // Leave the run half-done rather than push a server that is
+      // already refusing us; the summary tells the user what remains.
+      if (abortedReason) break;
+
+      await sleep(THROTTLE_MS);
     }
 
     importing = false;
@@ -483,6 +549,16 @@
             {" "}{m.import_skipped({ count: String(skippedCount) })}
           {/if}
         </p>
+        {#if abortedReason}
+          <!-- The remaining entries were never attempted, so say how many
+               and why — a bare failure count would read as "these items
+               are bad" rather than "the server stopped us". -->
+          <p class="import-aborted">
+            {abortedReason === "blocked"
+              ? m.import_aborted_blocked({ remaining: String(plannedCount - progress) })
+              : m.import_aborted_rate_limited({ remaining: String(plannedCount - progress) })}
+          </p>
+        {/if}
         {#if failures.length > 0}
           <div class="import-failures">
             <p>{m.import_failures_heading()}</p>
@@ -716,6 +792,17 @@
   .import-done {
     margin: 0.5rem 0;
     font-size: 0.9rem;
+  }
+
+  /* Amber, not the failures' red: the entries that remain aren't bad,
+     they were never sent. */
+  .import-aborted {
+    color: #7a3b00;
+    background: #fdf3e0;
+    padding: 0.4rem 0.6rem;
+    border-radius: 6px;
+    margin: 0.5rem 0;
+    font-size: 0.85rem;
   }
 
   .kdbx-password-row {


### PR DESCRIPTION
## What happened

A 1100-item import fired 1100 back-to-back `POST /api/ciphers/create` with no spacing and no reaction to failures. Observed on a real Vaultwarden behind BunkerWeb — from the WAF's access log:

```
1114 × POST /api/ciphers/create → 403
  53 × POST /api/ciphers/create → 429
   9 × POST /api/ciphers/create → 200
```

```
[BADBEHAVIOR] IP <redacted> is banned for 3600s (52/30) on server <vault host>
```

The sequence: the server's own rate limiter answered **429** → the WAF counted those 429s as bad behaviour → at its 30-strike threshold it **banned the client for an hour** → every subsequent request got **403** → and the loop kept going, sending 1114 more requests into the ban.

**9 items out of ~1176 were created.** The loop turned a rate limit into a self-inflicted denial of service against the user's own server, then reported ~1100 individual item failures as if the data were at fault.

## Changes

- **Space writes 60 ms apart.** A 1100-item import takes about a minute longer — the right trade against tripping a rate limiter.
- **Retry a 429 with exponential backoff** (1 s, doubling, 5 attempts). That is the one status where waiting is the correct response.
- **Stop the run on a 403**, or on a 429 that outlived its retries. A 403 means something in front of the server has decided against us, and retrying is precisely what escalates a refusal into a ban.

The summary now distinguishes *"the server stopped us, N items were never attempted"* from *"these N items were rejected"* — the old wording blamed the data for what was a transport problem. Re-running is safe: the duplicate filter already skips what exists.

## Note for review

`abortedReason` is cleared at **both** reset sites. Missing the one in `startImport` would make a second run break on its first iteration and import nothing.

The extracted `payload` const is explicitly typed `EditorPayload`: hoisting the literal out of the call site loses the contextual typing that narrowed `cipherType` to `CipherKind`.

## Tests

- `pnpm run check` — 1117 files, 0 errors
- `pnpm vitest run` — 135 tests pass

Not covered by an automated test: the retry/abort paths need a mocked `api.createCipher` returning crafted `http_status` errors, which the import suite has no harness for today. Worth adding if this area grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SffAkhYYDgKbsJFNuqNMvY