### PR TITLE
fix(import): learn the server's rate limit instead of guessing it

### DIFF
--- a/src/lib/ImportDialog.svelte
+++ b/src/lib/ImportDialog.svelte
@@ -79,7 +79,16 @@
   //
   // Hence: space the writes out, back off when told to, and stop rather
   // than hammer a server that is refusing us.
-  const THROTTLE_MS = 60;
+  // Starting spacing. 60ms was a guess, and it was wrong: against a
+  // proxy capped at 5 r/s it still produced 6 r/s once latency was
+  // accounted for, so the run kept earning 429s. 200ms targets 5 r/s,
+  // which clears the common default — but the number below matters far
+  // less than the fact that it adapts, since the client cannot know any
+  // given deployment's limit.
+  const INITIAL_THROTTLE_MS = 200;
+  // Ceiling for the learned spacing: past this the import is so slow
+  // that stopping and telling the user beats grinding on.
+  const MAX_THROTTLE_MS = 2000;
   const MAX_RATE_LIMIT_RETRIES = 5;
   const BASE_BACKOFF_MS = 1000;
 
@@ -255,6 +264,10 @@
     // Must be cleared here too: without it a second run would break out
     // of the loop on its first iteration, importing nothing.
     abortedReason = null;
+    // Each run relearns the pace from scratch. Carrying a widened value
+    // over would make a retry of a once-throttled import needlessly slow
+    // even against a server that is no longer limiting.
+    let throttleMs = INITIAL_THROTTLE_MS;
     plannedCount = toImport.length;
     // Everything parsed but left out of this run: duplicates plus unchecked rows.
     skippedCount = entries.length - toImport.length;
@@ -313,6 +326,13 @@
             const status = httpStatusOf(e);
             if (status === 429 && attempt < MAX_RATE_LIMIT_RETRIES) {
               attempt += 1;
+              // Slow the *rest of the run*, not just this retry. Backing
+              // off only the retry leaves the base pace above the limit,
+              // so the next items earn their own 429s — and a WAF that
+              // counts 429s as bad behaviour bans the client long before
+              // the import ends. Widening permanently converges under
+              // whatever limit this deployment actually enforces.
+              throttleMs = Math.min(throttleMs * 2, MAX_THROTTLE_MS);
               await sleep(BASE_BACKOFF_MS * 2 ** (attempt - 1));
               continue;
             }
@@ -339,7 +359,7 @@
       // already refusing us; the summary tells the user what remains.
       if (abortedReason) break;
 
-      await sleep(THROTTLE_MS);
+      await sleep(throttleMs);
     }
 
     importing = false;


### PR DESCRIPTION
## What #205 missed

#205 stopped the import from hammering a server that refused it. It did **not** stop the import from tripping the limit that caused the refusal. Second run on the same deployment:

```
155 × POST /api/ciphers/create → 200   (up from 9)
 30 × POST /api/ciphers/create → 429
  1 × POST /api/ciphers/create → 403   ← the abort from #205 working
```

```
[BADBEHAVIOR] IP <redacted> is banned for 3600s (30/30)
```

The abort worked — one request touched the ban instead of 1114. But 30 × 429 hit the ban threshold exactly.

## The actual limit

The proxy log named it:

```
[ACCESS] denied access from limit : client IP <redacted> is limited for URL
/api/ciphers/create (current rate = 6r/s and max rate = 5r/s)
```

Two things follow:

1. **The 429s come from the reverse proxy, not the vault server.** And the same proxy's bad-behaviour module counts those 429s as attack evidence and bans the client. It tells you to slow down, then punishes you for having been told.
2. **60 ms was a guess.** It targeted ~16 r/s; measured 6 r/s once latency was counted, against a 5 r/s cap. Any hardcoded number is wrong somewhere, because the client cannot know a given deployment's limit.

## Fix

The spacing **adapts**: starts at 200 ms (5 r/s, clearing the common default) and doubles on every 429, capped at 2 s, **for the rest of the run**.

Backing off only the retry — what #205 did — left the base pace above the limit, so each following item earned its own 429. That is how 30 accumulated while the retries themselves looked well-behaved.

The learned value resets per run: carrying it over would make a retry of a once-throttled import needlessly slow against a server that is no longer limiting.

## Tests

- `pnpm run check` — 1117 files, 0 errors
- `pnpm vitest run` — 135 tests pass

Still no automated coverage of the retry/adapt/abort paths — same gap flagged in #205. The evidence here is production logs, not a test, and that's worth being honest about.

## Server-side note

This is worth fixing on the deployment too: a WAF that counts its own rate-limit 429s toward a ban threshold will ban well-behaved clients that back off correctly. Excluding 429 from the bad-behaviour status list, for the vault service, removes the feedback loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SffAkhYYDgKbsJFNuqNMvY