### PR TITLE
chore(deps-rust): bump base64 to 0.23 without the unsafe SIMD engines

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -378,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,7 +811,7 @@ version = "0.13.1"
 dependencies = [
  "aes 0.8.4",
  "argon2",
- "base64 0.22.1",
+ "base64 0.23.0",
  "cbc 0.1.2",
  "ctap-hid-fido2",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,12 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 pbkdf2 = "0.12"
 sha2 = "0.10"
 argon2 = "0.5"
-base64 = "0.22"
+# 0.23 turned on SIMD engines by default, which flips the crate from
+# `forbid(unsafe_code)` to `deny` and compiles hand-written AVX2/NEON
+# intrinsics into a binary that handles vault keys. We only ever use the
+# scalar `general_purpose` engines, so drop the default features and keep
+# the unsafe code out of the tree.
+base64 = { version = "0.23", default-features = false, features = ["std"] }
 zeroize = { version = "1", features = ["derive"] }
 secrecy = "0.10"
 uuid = { version = "1", features = ["v4"] }


### PR DESCRIPTION
Supersedes #213.

base64 0.23 is API-compatible for us — every call site goes through the `Engine` trait with `general_purpose::STANDARD` / `URL_SAFE_NO_PAD`, and nothing pattern-matches `DecodeError` (whose `InvalidLastSymbol` variant changed shape in this release).

What Dependabot's version of the bump would also have brought in is the new default feature set:

```toml
default = ["std", "simd-unsafe"]
```
```rust
#![cfg_attr(not(feature = "simd-unsafe"), forbid(unsafe_code))]
#![cfg_attr(feature = "simd-unsafe",      deny(unsafe_code))]
```

That compiles hand-written AVX2/NEON intrinsics into a binary that handles vault keys, and buys us nothing: we never construct the `Simd`/`Avx2`/`Neon` engines, so `GeneralPurpose` stays scalar regardless. This PR takes the same version with `default-features = false, features = ["std"]`, which keeps base64 a `forbid(unsafe_code)` crate.

Verified locally:
- `cargo tree -e features -i base64@0.23.0` → only `std` / `alloc` reach us, no `simd-unsafe`
- `cargo clippy --all-targets --locked -- -D warnings` clean
- `cargo test --tests --locked` → 215 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdcF49Q8azEipN4uCHpFLb