### PR TITLE
ci: make the --locked guard real and keep Cargo.lock on the release train

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,14 @@ jobs:
       - name: cargo fmt (check)
         run: cargo fmt --all -- --check
 
+      # `--locked` has to be on the FIRST cargo invocation, not just on the
+      # test step: clippy without it silently regenerates Cargo.lock on the
+      # runner, so the later `--locked` guard only ever validated a lock CI
+      # had just rewritten. That is how the committed lock sat at clavix
+      # 0.11.0 while Cargo.toml said 0.13.1, across three releases, with CI
+      # green the whole time.
       - name: cargo clippy (strict)
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets --locked -- -D warnings
 
       # `--tests` covers both lib unit tests AND integration tests
       # under `src-tauri/tests/` (refresh_token_endpoint,

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,34 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+      # release-please bumps the version in src-tauri/Cargo.toml (see
+      # `extra-files`) but knows nothing about Cargo.lock, which carries the
+      # same version for the `clavix` package. Left alone the two drift, and
+      # what we tag is no longer what `--locked` resolves — the lock said
+      # 0.11.0 while the manifest said 0.13.1 for three releases running.
+      # Re-resolve on the release branch so the bump lands as one commit.
+      # release-please force-pushes that branch on every master push, which
+      # drops this commit; the same run then puts it back.
+      - name: Check out the release branch
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ fromJson(steps.release.outputs.pr).headBranchName }}
+
+      - name: Keep Cargo.lock in step with the released version
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        run: |
+          # Resolution only — no compiler, no Tauri system deps needed.
+          cargo metadata --manifest-path src-tauri/Cargo.toml --format-version 1 > /dev/null
+          if git diff --quiet -- src-tauri/Cargo.lock; then
+            echo "Cargo.lock already matches the release version"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: sync Cargo.lock with the released version" -- src-tauri/Cargo.lock
+          git push
+
       # A tag pushed by GITHUB_TOKEN does NOT fire release.yml's
       # `push: tags` trigger — GitHub refuses to chain workflow runs off
       # its own token, to avoid recursion. workflow_dispatch is the


### PR DESCRIPTION
Fallout from reviewing the Dependabot PRs: both Rust ones carried a line neither their changelog nor Dependabot mentioned —

```diff
 name = "clavix"
-version = "0.11.0"
+version = "0.13.1"
```

The committed `Cargo.lock` had been stale since the 0.12 release. Verified against master before #212 landed:

```
$ cargo metadata --locked
error: cannot update the lock file … because --locked was passed
```

CI stayed green through all of it because `cargo clippy --all-targets` (ci.yml:65) runs **without** `--locked` and regenerates the lock on the runner, so `cargo test --tests --locked` (ci.yml:73, :83) was validating a lock CI had just written. The guard was a no-op.

**Two changes:**

1. `--locked` moves up to the first cargo invocation (clippy), where it actually enforces something.
2. `release-please.yml` re-resolves `Cargo.lock` on the release branch and commits it there. release-please bumps `src-tauri/Cargo.toml` via `extra-files` but has no updater for the lock, which carries the same version for the `clavix` package — that's the drift's source. Without this, change 1 turns master red after every release. The step is guarded on `prs_created`, does resolution only (`cargo metadata`, so no compiler or Tauri system deps), and no-ops when the lock already matches. release-please force-pushes the release branch on each master push, dropping the commit; the same run re-adds it.

Verified: `cargo metadata --locked` now passes on master, and both workflow files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdcF49Q8azEipN4uCHpFLb