### PR TITLE
chore(deps-rust): bump wayland-scanner, drop two cargo-audit ignores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,18 +101,14 @@ jobs:
       # sur le déchiffrement RSA-OAEP). Pas de fix upstream disponible à ce jour.
       # Notre exposition est faible : déchiffrement d'org keys une fois par sync,
       # HTTPS vers Vaultwarden, pas d'oracle exposé à un attaquant. À retirer dès
-      # que le crate `rsa` publie une version constant-time.
+      # que le crate `rsa` publie une version constant-time (0.10 n'existe
+      # toujours qu'en release candidate).
       #
-      # RUSTSEC-2026-0194 / RUSTSEC-2026-0195 : DoS (run time quadratique et
-      # allocation non bornée) dans `quick-xml` < 0.41.0, tiré transitivement par
-      # `wayland-scanner` 0.31.10 (dernière version publiée, pas encore de fix
-      # upstream). `wayland-scanner` génère du code à la compilation à partir de
-      # fichiers XML de protocole *fiables* fournis par les crates wayland : le XML
-      # n'est jamais contrôlé par un attaquant, l'avis ne s'applique pas à notre
-      # usage. La copie vulnérable via `plist` a été corrigée par `plist` 1.10.0.
-      # À retirer dès que `wayland-scanner` passe à `quick-xml` >= 0.41.0.
+      # RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (`quick-xml` < 0.41.0) ne sont plus
+      # ignorés : `wayland-scanner` 0.31.11 est passé à `quick-xml` ^0.41, donc
+      # plus aucune copie vulnérable dans l'arbre.
       - name: cargo audit
-        run: cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195
+        run: cargo audit --ignore RUSTSEC-2023-0071
 
   frontend:
     name: Frontend (svelte-check)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2881,7 +2881,7 @@ dependencies = [
  "hybrid-array",
  "indexmap 2.14.0",
  "js-sys",
- "quick-xml 0.41.0",
+ "quick-xml",
  "rust-argon2",
  "salsa20",
  "secrecy",
@@ -3960,7 +3960,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml 0.41.0",
+ "quick-xml",
  "serde",
  "time",
 ]
@@ -4162,15 +4162,6 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
-
-[[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "quick-xml"
@@ -6587,12 +6578,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.10"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml",
  "quote",
 ]
 


### PR DESCRIPTION
`cargo audit` carried three `--ignore` flags. Two of them are no longer needed.

**Dropped — RUSTSEC-2026-0194 / RUSTSEC-2026-0195** (quadratic run time + unbounded allocation in `quick-xml` < 0.41.0). The ignore comment said "à retirer dès que `wayland-scanner` passe à `quick-xml` >= 0.41.0" — that happened: 0.31.11 depends on `quick-xml ^0.41`. `cargo update -p wayland-scanner` removes the last `quick-xml 0.39.2` from the tree, so only 0.41.0 remains and the advisories no longer match anything.

**Kept — RUSTSEC-2023-0071** (Marvin Attack on `rsa`). Still no constant-time stable release: the index only has `0.10.0-rc.18` past the 0.9 line. Comment updated to say so.

Verified: `quick-xml` appears once in `Cargo.lock` (0.41.0), `cargo clippy --all-targets --locked -- -D warnings` clean. The audit step itself runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdcF49Q8azEipN4uCHpFLb