### PR TITLE
chore(deps-npm): clear the js-yaml and brace-expansion advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,10 +5,12 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion@<1.1.16: ^1.1.16
+  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
   cookie@<0.7.0: ^0.7.0
   cross-spawn@<7.0.5: ^7.0.6
   esbuild@<0.25.0: ^0.25.0
-  js-yaml@<4.1.2: ^4.1.2
+  js-yaml@<4.3.0: ^4.3.0
   kysely@<0.28.17: ^0.28.17
   minimatch@<3.1.3: ^3.1.3
   serialize-javascript@<7.0.5: ^7.0.5
@@ -827,11 +829,11 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1451,8 +1453,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsdom@29.1.1:
@@ -3256,12 +3258,12 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -3893,7 +3895,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -4085,15 +4087,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimatch@6.2.3:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 
@@ -4112,7 +4114,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       log-symbols: 4.1.0
       minimatch: 5.1.9
       ms: 2.1.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,10 +2,18 @@
 # Moved here from the `pnpm.overrides` field in package.json, which pnpm 11+
 # no longer reads (see https://pnpm.io/settings).
 overrides:
+  # GHSA-3jxr-9vmj-r5cp, backported to both lines the wdio chain pulls in.
+  # Do NOT collapse these into `brace-expansion@<5.0.8: ^5.0.8` to also cover
+  # GHSA-mh99-v99m-4gvg: 5.x exports `{ expand }` instead of the callable
+  # default, so every minimatch <= 6 dies with "expand is not a function".
+  # Only minimatch >= 9.0.6 speaks that API, and getting there means moving
+  # @wdio off v7 — see the follow-up issue.
+  brace-expansion@<1.1.16: ^1.1.16
+  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
   cookie@<0.7.0: ^0.7.0
   cross-spawn@<7.0.5: ^7.0.6
   esbuild@<0.25.0: ^0.25.0
-  js-yaml@<4.1.2: ^4.1.2
+  js-yaml@<4.3.0: ^4.3.0
   kysely@<0.28.17: ^0.28.17
   minimatch@<3.1.3: ^3.1.3
   serialize-javascript@<7.0.5: ^7.0.5


### PR DESCRIPTION
Closes the three open Dependabot alerts (#33, #34, #35). All dev-only, all transitive under the wdio v7 E2E chain:

| package | advisory | path |
|---|---|---|
| js-yaml 4.2.0 | GHSA-52cp-r559-cp3m | `@wdio/mocha-framework > mocha > js-yaml` |
| brace-expansion 1.1.14 | GHSA-3jxr-9vmj-r5cp | `@wdio/cli > recursive-readdir > minimatch` |
| brace-expansion 2.1.0 | GHSA-3jxr-9vmj-r5cp | `@wdio/cli > @wdio/config > glob > minimatch` |

Fixed through the existing security-override block in `pnpm-workspace.yaml`.

**Why brace-expansion is pinned per line rather than to 5.x.** My first attempt was `brace-expansion@<5.0.8: ^5.0.8`, which would also have covered GHSA-mh99-v99m-4gvg. It installs cleanly and breaks everything — 5.x dropped the callable default export in favour of a named `{ expand }`:

```
minimatch@3.1.5 ERROR: expand is not a function
minimatch@5.1.9 ERROR: expand is not a function
minimatch@6.2.3 ERROR: (0 , brace_expansion_1.default) is not a function
```

Only minimatch >= 9.0.6 speaks that API. So the override sticks to 1.1.16 / 2.1.2, the backported fixes for GHSA-3jxr on each line.

**What's left.** GHSA-mh99-v99m-4gvg (unbounded expansion → OOM) is only fixed in 5.0.8, so it survives this PR — `pnpm audit` goes 5 findings → 2, both that one advisory. Clearing it means minimatch >= 9, which means moving @wdio off v7; filed as a follow-up. It's dev tooling that never reaches a shipped artifact, and the only patterns fed to it are our own test globs.

Verified: `pnpm audit` (5 → 2), each installed minimatch still expands braces correctly at runtime, `pnpm check` 0 errors, `pnpm test` 135 passed. E2E is covered by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdcF49Q8azEipN4uCHpFLb