### PR TITLE
fix(auto-lock): stop the TOTP poll from defeating the idle watchdog

### DIFF
--- a/src-tauri/src/commands/cipher.rs
+++ b/src-tauri/src/commands/cipher.rs
@@ -182,9 +182,17 @@ fn decrypt_totp_secret(state: &AppState, id: &str) -> Result<Option<String>> {
 /// Current TOTP code + seconds remaining for a login item. Computed in Rust so
 /// the shared secret stays out of the WebView (a leaked seed = permanent 2FA
 /// bypass). The renderer polls this once a second for the live field.
+///
+/// Deliberately does **not** call `mark_activity`. A timer firing on its own
+/// is not a user being present, and at one call a second this was enough to
+/// hold `last_activity` permanently fresh: with any TOTP item selected the
+/// backend auto-lock watchdog could never reach its idle threshold, including
+/// on a locked screen with nobody at the machine. The renderer's own idle
+/// timer never counted these polls either — it only watches mouse and
+/// keyboard — so dropping this makes the two agree rather than changing what
+/// a user sees.
 #[tauri::command]
 pub fn totp_code(state: State<'_, AppState>, id: String) -> Result<crate::totp::TotpCode> {
-    crate::state::mark_activity(&state);
     let secret = decrypt_totp_secret(&state, &id)?.ok_or_else(|| Error::Storage {
         reason: "item has no TOTP secret".into(),
     })?;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -134,6 +134,13 @@ pub const PENDING_2FA_TTL_SECS: u64 = 300;
 
 /// Bumps `last_activity` to now. Cheap; called at the start of any command
 /// that proves the user is still around (sync, decrypt, refresh, etc).
+///
+/// Only ever call this from a command that follows a *discrete* user action.
+/// Never from one the renderer polls on a timer: `totp_code` used to call it,
+/// and since the TOTP field re-reads the code once a second, one visible TOTP
+/// item was enough to keep this timestamp fresh forever and stop the auto-lock
+/// watchdog from ever firing. A poll proves a timer is running, not that
+/// anyone is there.
 pub fn mark_activity(state: &AppState) {
     *state.last_activity.lock() = Instant::now();
 }


### PR DESCRIPTION
## The bug

`totp_code` called `mark_activity`, and `TotpField.svelte` polls it **once a second** for as long as a TOTP item is displayed. That kept `last_activity` permanently fresh: with any such item selected, the backend auto-lock watchdog could never reach its idle threshold.

Net effect: the vault stayed unlocked indefinitely — including on a locked screen with nobody at the machine — as long as a TOTP entry was the selected item.

## The fix

Drop the call. A timer firing on its own is not a user being present.

## Scope

This is the **backend safety net** only. The renderer's idle timer watches `mousemove` / `keydown` / `click` and never counted these polls, so it still locked on schedule. The fix makes the two layers agree rather than changing what a user sees.

The real exposure was precisely the case the safety net exists for — a frozen WebView, or JS timers disabled from an inspector — where nothing at all was left guarding the session.

## Testing

`cargo clippy --all-targets -- -D warnings` clean, 204 unit tests pass.

No regression test: `totp_code` takes a `tauri::State`, which can't be constructed outside a running app, and the existing suite tests helper functions rather than command entry points. Rather than refactor the command to make one line assertable, the invariant is documented on `mark_activity` itself — *only call this from a command that follows a discrete user action, never from one the renderer polls* — where the next person to add a caller will actually read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016euvgMZh8eEGCcfQ9F3aXu