### PR TITLE
fix(search): keep the query when switching folders

### DIFF
--- a/src/lib/vault.svelte.ts
+++ b/src/lib/vault.svelte.ts
@@ -216,25 +216,18 @@ export class VaultController {
     void this.sync();
   }
 
+  // Navigation keeps the search box intact: the query narrows *within*
+  // whatever folder / quick filter is active, so browsing around while
+  // hunting for an item no longer means retyping the query at every
+  // click. When the combination matches nothing, the list's empty state
+  // offers "Effacer la recherche" as the way out.
   selectQuickFilter(f: QuickFilter) {
     this.quickFilter = f;
     this.selectedKey = null;
-    this.clearSearch();
   }
 
   selectNode(key: string) {
     this.selectedKey = this.selectedKey === key ? null : key;
-    this.clearSearch();
-  }
-
-  // Wipe both the raw input and the debounced mirror so the filter
-  // recomputes immediately. Leaving searchDebounced behind would keep
-  // the list narrowed for ~150ms after a folder click, which reads as
-  // "click did nothing" — the exact symptom this method fixes.
-  private clearSearch() {
-    if (this.search === "" && this.searchDebounced === "") return;
-    this.search = "";
-    this.searchDebounced = "";
   }
 
   toggleSort(key: SortKey) {


### PR DESCRIPTION
## Problème

Le champ de recherche se vidait à chaque clic dans l'arborescence : `selectNode()` et `selectQuickFilter()` appelaient `clearSearch()`, qui effaçait `search` **et** son miroir `searchDebounced`. Conséquence : chercher un item en parcourant les dossiers obligeait à retaper la requête à chaque étape.

## Correctif

La navigation ne touche plus au champ de recherche. La requête filtre *à l'intérieur* du dossier / filtre rapide sélectionné — le comportement de Bitwarden.

- Dossiers, collections, organisations et filtres rapides (Tous / Favoris / Corbeille) sont traités de la même façon, sinon la recherche survivrait à un clic sur un dossier mais pas sur « Favoris ».
- `reset()` vide toujours la recherche au verrouillage / déconnexion : une nouvelle session repart propre.
- Quand dossier + recherche ne donnent rien, l'état vide de `CipherList.svelte` affiche déjà « Aucun résultat » avec un bouton « Effacer la recherche » : c'est la sortie de secours que l'effacement automatique remplaçait.

Le `clearSearch()` supprimé purgeait aussi `searchDebounced` pour éviter que la liste reste filtrée ~150 ms après un clic (effet « le clic n'a rien fait »). Ce risque disparaît : la navigation ne modifie plus la valeur debouncée, donc le filtre se recalcule immédiatement.

## Tests

- `pnpm check` — 0 erreur, 0 avertissement
- `pnpm test` — 145 tests, tous verts

Validation visuelle dans l'app réelle laissée à la prochaine release, à la demande de l'auteur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011vUCRcbhqgaBEwTVFh49qV