### PR TITLE
feat: one Clavix per session, and Entrée on the SSH consent prompt

### DIFF
--- a/MANUAL_VALIDATION.md
+++ b/MANUAL_VALIDATION.md
@@ -189,8 +189,8 @@ individual sign call's.
   are skipped by the agent. Adding ECDSA is tracked as part of the
   SSH-agent roadmap.
 - **One agent per running Clavix instance.** Two simultaneous
-  sessions would race on the same socket path; this is not the
-  intended usage.
+  sessions would race on the same socket path; the single-instance
+  guard (see that checklist) now prevents the accidental case.
 - **No per-signature consent prompt** today. Once the agent is
   enabled, every `ssh`/`git` call signs silently. A "ask before
   sign" mode is on the roadmap but not in this checklist.
@@ -263,3 +263,58 @@ actually reports its lock state. That is what this checklist is for.
 - **Windows reports the UAC secure desktop as locked**, so an
   "Immédiatement" setting can lock the vault when a consent prompt
   appears. Errs on the safe side; note it if it surprises a tester.
+
+---
+
+## Single instance
+
+Code path: `tauri_plugin_single_instance` registered first in
+`src-tauri/src/lib.rs::run`, with `commands::tray::raise_main_window` as
+the "someone tried to launch me again" callback.
+
+Nothing here is automatable: the whole point is the behaviour of a
+*second process* against a live desktop session, and the E2E suite runs
+with the guard disabled (`CLAVIX_ALLOW_MULTIPLE_INSTANCES=1` in
+`tests/e2e/wdio.conf.mjs`) precisely so it can relaunch the binary
+between specs.
+
+### Platform matrix
+
+- **Linux** — a well-known name on the session D-Bus, derived from the
+  bundle identifier. Per session bus, so a second *user session* (fast
+  user switching, a separate X/Wayland login) legitimately gets its own
+  instance.
+- **macOS / Windows** — the plugin's own primitives (a listener socket /
+  a named mutex). Same user-scoped behaviour.
+
+### Happy path
+
+- [ ] **Second launch raises the first** — start Clavix, then run
+  `clavix` again from a terminal. No second window and no second tray
+  icon appear; the existing window comes to the front, focused. The
+  second process exits on its own (the shell gets its prompt back).
+- [ ] **Works from the tray** — close Clavix to the tray (window hidden),
+  then launch it again from the app menu. The hidden window is restored
+  and focused rather than a new process starting.
+- [ ] **Works while minimised** — minimise, relaunch: the window is
+  unminimised and focused.
+- [ ] **SSH agent keeps its socket** — with the agent started and
+  `ssh-add -l` listing keys against `$SSH_AUTH_SOCK`, relaunch Clavix and
+  re-run `ssh-add -l`. Same keys, same socket — no rebind. (Before this
+  guard, instance #2 unlinked and re-bound `agent.sock`, and `ssh-add -l`
+  answered from a locked vault.)
+- [ ] **Quit then relaunch** — quit from the tray menu, launch again. The
+  app starts normally; the lock is released on exit, not leaked.
+- [ ] **Escape hatch** — `CLAVIX_ALLOW_MULTIPLE_INSTANCES=1 clavix`
+  starts a second instance alongside the first. Expect the SSH-agent
+  socket takeover described above if both agents are started; that is
+  the documented cost of the opt-out.
+
+### Known limitations
+
+- **Debug and release builds share the identifier**, so a packaged
+  Clavix in the tray will stop `pnpm tauri dev` from booting. Use the
+  escape-hatch env var when developing with the daily driver running.
+- **A hard-killed instance on Linux** (SIGKILL) releases its bus name
+  when the connection drops, so the next launch works. A frozen —
+  not dead — process still holds the name and will simply be raised.

--- a/MANUAL_VALIDATION.md
+++ b/MANUAL_VALIDATION.md
@@ -146,6 +146,18 @@ button.
   writing the private key to disk.
 - [ ] `git ls-remote git@<host>:<path>.git` works the same way (this
   is the realistic developer use case).
+- [ ] **Consent prompt, keyboard only** — with a confirming sign
+  policy, trigger a signature and touch neither mouse nor Tab.
+  **Entrée** approves (focus lands on *Autoriser*), **Échap** denies,
+  and both answers reach `ssh`/`git` immediately. Repeat with two
+  signatures in flight (`git ls-remote` on a repo with submodules, or
+  two `ssh` calls at once): the second prompt opens with focus on
+  *Autoriser* too, not on the dialog frame.
+- [ ] **Held Entrée does not chain approvals** — same two-signature
+  setup, but hold Entrée down through both prompts (keyboard
+  autorepeat). The second prompt must still be waiting when you let
+  go: each one arms its own 300 ms window. Approving deliberately
+  should feel instant — if the delay is perceptible, say so.
 
 **Expected**: signatures use the in-memory decrypted keys held by
 the running agent's `KeyStore`. Those keys are **never written to
@@ -191,9 +203,14 @@ individual sign call's.
 - **One agent per running Clavix instance.** Two simultaneous
   sessions would race on the same socket path; the single-instance
   guard (see that checklist) now prevents the accidental case.
-- **No per-signature consent prompt** today. Once the agent is
-  enabled, every `ssh`/`git` call signs silently. A "ask before
-  sign" mode is on the roadmap but not in this checklist.
+- **The consent prompt defaults to Autoriser.** With a confirming
+  sign policy, the dialog opens with focus on **Autoriser**, so
+  Entrée approves. Esc, the backdrop and the 30 s timeout all deny.
+  Approvals are ignored for the first 300 ms after the prompt appears,
+  which absorbs a keystroke or click already in flight; a keystroke
+  aimed elsewhere that arrives *later*, while the Clavix window has
+  focus, still approves. Deliberate, and the reason the fingerprint
+  and calling process are on the prompt.
 
 ---
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-opener",
+ "tauri-plugin-single-instance",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -5617,6 +5618,22 @@ dependencies = [
  "thiserror 2.0.19",
  "url",
  "windows",
+ "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
  "zbus",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,6 +21,11 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
+# Second launch hands off to the running process instead of booting a
+# rival one. Beyond the duplicate windows, a second instance would
+# `remove_file` + rebind the SSH agent socket (`ssh_agent.rs`), silently
+# stealing SSH_AUTH_SOCK from the vault the user actually unlocked.
+tauri-plugin-single-instance = "2"
 tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/commands/tray.rs
+++ b/src-tauri/src/commands/tray.rs
@@ -208,8 +208,10 @@ pub fn set_tray_locale(app: AppHandle, locale: String) -> Result<()> {
     Ok(())
 }
 
-/// Raise the main window and give it focus. Two GNOME/X11 quirks
-/// stack here:
+/// Raise the main window and give it focus. Used by the tray
+/// (Ouvrir / left-click) and by the single-instance callback in
+/// `lib.rs`, where a second launch is answered by surfacing the
+/// window the user already has. Two GNOME/X11 quirks stack here:
 ///
 ///   1. `tao`'s Linux backend forwards every window op
 ///      (`show`, `unminimize`, `set_focus`, …) through a glib
@@ -239,7 +241,7 @@ pub fn set_tray_locale(app: AppHandle, locale: String) -> Result<()> {
 /// and `get_visible()` to return true. No-op on Windows/macOS
 /// where `set_focus()` alone already raises — the deferred dance
 /// is harmless there.
-fn raise_main_window(app: &AppHandle) {
+pub(crate) fn raise_main_window(app: &AppHandle) {
     if let Some(window) = app.get_webview_window(MAIN_WINDOW) {
         // Clear any skip-taskbar hint set on the way down by the
         // hide_dock_on_tray path. Safe to call unconditionally: a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,9 +34,38 @@ use tauri::Manager;
 
 use state::AppState;
 
+/// Escape hatch for the single-instance lock. Set to any value to let
+/// a second Clavix boot alongside a running one — needed by the E2E
+/// suite (which relaunches the binary between specs while a dev build
+/// may sit in the tray) and by anyone deliberately running two vaults.
+const ALLOW_MULTIPLE_INSTANCES_ENV: &str = "CLAVIX_ALLOW_MULTIPLE_INSTANCES";
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let mut builder = tauri::Builder::default();
+
+    // Single-instance guard, registered before every other plugin as
+    // the plugin's docs require. A second launch never reaches the rest
+    // of this builder: the plugin hands argv over to the running
+    // process (which just raises its window) and exits.
+    //
+    // Two windows are the visible symptom; the real damage is the SSH
+    // agent. `ssh_agent.rs` unlinks any stale socket before binding, so
+    // instance #2 starting its agent would take over
+    // `$XDG_RUNTIME_DIR/clavix/agent.sock` — every ssh(1) already
+    // pointing at SSH_AUTH_SOCK would then be served by a vault that is
+    // very likely still locked, with no error explaining why the keys
+    // vanished.
+    if std::env::var_os(ALLOW_MULTIPLE_INSTANCES_ENV).is_none() {
+        builder = builder.plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
+            // Reuse the tray's raise path: it handles the
+            // hidden-to-tray and minimised cases, and carries the
+            // GNOME/X11 focus dance we already needed there.
+            commands::tray::raise_main_window(app);
+        }));
+    }
+
+    builder
         .manage(AppState::default())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_clipboard_manager::init())

--- a/src/lib/SshConfirmDialog.svelte
+++ b/src/lib/SshConfirmDialog.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
   import { listen, type UnlistenFn } from "@tauri-apps/api/event";
   import * as m from "$lib/paraglide/messages";
   import { api } from "./api";
@@ -20,12 +20,25 @@
   // nobody answers doesn't linger with buttons that no longer do anything.
   const TIMEOUT_MS = 30_000;
 
+  // The dialog opens with focus on Autoriser (see `show`), which means an
+  // Entrée — or a click — already aimed somewhere else when the prompt
+  // appears would approve a signature nobody read. Swallow approvals for
+  // the first 300 ms: long enough to absorb a keystroke in flight, short
+  // enough that someone reaching for Autoriser never waits on it (reading
+  // the fingerprint takes seconds, not milliseconds). Denials are
+  // deliberately not guarded — refusing early is always safe, and a
+  // stray Échap costs one retried `ssh`.
+  const ARM_DELAY_MS = 300;
+
   let dialog = $state<HTMLDialogElement | null>(null);
+  let allowButton = $state<HTMLButtonElement | null>(null);
   let current = $state<ConfirmReq | null>(null);
   // Signatures can arrive in parallel (e.g. `git` opening several
   // connections); queue extras and show them one at a time.
   let queue = $state<ConfirmReq[]>([]);
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let armTimer: ReturnType<typeof setTimeout> | null = null;
+  let armed = false;
 
   onMount(() => {
     let unlisten: UnlistenFn | null = null;
@@ -36,14 +49,48 @@
     return () => unlisten?.();
   });
 
-  function show(req: ConfirmReq) {
+  // `await tick()` before opening: `showModal()` runs the dialog's focus
+  // algorithm once, at open time, and Svelte 5 flushes the `{#if current}`
+  // block on a microtask. Opening first would therefore run that algorithm
+  // against an empty dialog, leaving focus on the <dialog> element itself
+  // — Entrée then did nothing at all, and Tab was needed to reach any
+  // button. With the content mounted, `showModal()` lands on the first
+  // focusable child (Refuser) and we move focus to Autoriser, so Entrée
+  // approves the signature. Esc still denies, as does the backdrop.
+  async function show(req: ConfirmReq) {
     current = req;
-    dialog?.showModal();
     if (timer) clearTimeout(timer);
     timer = setTimeout(() => respond(false), TIMEOUT_MS);
+    await tick();
+    // A queued request can be answered (or time out) while we await;
+    // don't open a dialog for a prompt that is no longer current.
+    // Compare ids, not references: `current` holds the `$state` proxy of
+    // `req`, so `current !== req` is true even for the same request
+    // (Svelte's `state_proxy_equality_mismatch` warning) and the dialog
+    // would never open. Ids come from a monotonic counter in Rust.
+    if (current?.id !== req.id) return;
+    dialog?.showModal();
+    allowButton?.focus();
+    // Arm only once the dialog is actually on screen — the delay is
+    // meant to cover the moment the user can see it, not the moment we
+    // decided to show it.
+    if (armTimer) clearTimeout(armTimer);
+    armTimer = setTimeout(() => (armed = true), ARM_DELAY_MS);
+  }
+
+  // Approve path, guarded by the arming delay. A swallowed activation is
+  // silent by design: at 300 ms the user is still moving, and a flash of
+  // error text would be worse noise than the second Entrée it costs.
+  function approve() {
+    if (armed) respond(true);
   }
 
   async function respond(approved: boolean) {
+    armed = false;
+    if (armTimer) {
+      clearTimeout(armTimer);
+      armTimer = null;
+    }
     if (timer) {
       clearTimeout(timer);
       timer = null;
@@ -113,7 +160,7 @@
       <button type="button" class="secondary" onclick={() => respond(false)}>
         {m.ssh_confirm_deny()}
       </button>
-      <button type="button" onclick={() => respond(true)}>
+      <button bind:this={allowButton} type="button" onclick={approve}>
         {m.ssh_confirm_allow()}
       </button>
     </div>

--- a/src/lib/SshConfirmDialog.svelte.test.ts
+++ b/src/lib/SshConfirmDialog.svelte.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, cleanup } from "@testing-library/svelte";
+import { tick } from "svelte";
+
+// The prompt is driven entirely by a Tauri event and answers over IPC;
+// both ends are mocked so the component test needs no backend.
+const evt = vi.hoisted(() => ({
+  cb: null as null | ((event: { payload: unknown }) => void),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async (_name: string, cb: (event: { payload: unknown }) => void) => {
+    evt.cb = cb;
+    return () => {};
+  }),
+}));
+
+const apiMock = vi.hoisted(() => ({
+  respondSshAgentConfirm: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("./api", () => ({ api: apiMock }));
+
+import SshConfirmDialog from "./SshConfirmDialog.svelte";
+
+// jsdom (29) still ships no <dialog> behaviour, so showModal/close are
+// stubbed to the two things the component relies on: the open flag and
+// the `close` event. Focus is deliberately NOT emulated — the component
+// focuses Autoriser itself rather than leaning on the browser's dialog
+// focus algorithm, which is exactly what these tests pin down.
+beforeEach(() => {
+  vi.useFakeTimers();
+  apiMock.respondSshAgentConfirm.mockClear();
+  HTMLDialogElement.prototype.showModal = function showModal(this: HTMLDialogElement) {
+    this.open = true;
+  };
+  HTMLDialogElement.prototype.close = function close(this: HTMLDialogElement) {
+    if (!this.open) return;
+    this.open = false;
+    this.dispatchEvent(new Event("close"));
+  };
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  evt.cb = null;
+});
+
+const REQ = {
+  id: 1,
+  comment: "laptop@clavix",
+  algorithm: "ssh-ed25519",
+  fingerprint: "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  callerName: "git",
+  callerPid: 4321,
+};
+
+// `show()` awaits a tick before opening (so the buttons exist when focus
+// is moved); a couple of flushes covers that plus the listen() promise.
+async function flush() {
+  for (let i = 0; i < 4; i++) await tick();
+}
+
+async function emit(req = REQ) {
+  evt.cb?.({ payload: req });
+  await flush();
+}
+
+function buttons() {
+  const all = Array.from(document.querySelectorAll("dialog button"));
+  return { deny: all[0] as HTMLButtonElement, allow: all[1] as HTMLButtonElement };
+}
+
+describe("SshConfirmDialog keyboard defaults", () => {
+  it("opens with focus on Autoriser, not on the dialog frame", async () => {
+    render(SshConfirmDialog);
+    await flush();
+    await emit();
+
+    const { allow } = buttons();
+    expect(allow.textContent?.trim()).toBe("Autoriser");
+    // Pressing Entrée activates the focused button — this is what makes
+    // Entrée mean "approve".
+    expect(document.activeElement).toBe(allow);
+  });
+
+  it("swallows an approval that lands inside the arming delay", async () => {
+    render(SshConfirmDialog);
+    await flush();
+    await emit();
+
+    buttons().allow.click();
+    await flush();
+    expect(apiMock.respondSshAgentConfirm).not.toHaveBeenCalled();
+    expect(document.querySelector("dialog")?.open).toBe(true);
+  });
+
+  it("approves once the arming delay has passed", async () => {
+    render(SshConfirmDialog);
+    await flush();
+    await emit();
+
+    vi.advanceTimersByTime(300);
+    buttons().allow.click();
+    await flush();
+    expect(apiMock.respondSshAgentConfirm).toHaveBeenCalledWith(1, true);
+  });
+
+  it("denies immediately — the delay guards approvals only", async () => {
+    render(SshConfirmDialog);
+    await flush();
+    await emit();
+
+    buttons().deny.click();
+    await flush();
+    expect(apiMock.respondSshAgentConfirm).toHaveBeenCalledWith(1, false);
+  });
+
+  it("re-arms for a queued request instead of inheriting the first one's state", async () => {
+    render(SshConfirmDialog);
+    await flush();
+    await emit();
+    // Second signature arrives while the first prompt is up (parallel
+    // `ssh` connections); it queues behind it.
+    await emit({ ...REQ, id: 2 });
+
+    vi.advanceTimersByTime(300);
+    buttons().allow.click();
+    await flush();
+    expect(apiMock.respondSshAgentConfirm).toHaveBeenCalledWith(1, true);
+
+    // The queued prompt is now showing: focused on Autoriser, and its own
+    // 300 ms window applies — a held Entrée must not carry through it.
+    const { allow } = buttons();
+    expect(document.activeElement).toBe(allow);
+    allow.click();
+    await flush();
+    expect(apiMock.respondSshAgentConfirm).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(300);
+    allow.click();
+    await flush();
+    expect(apiMock.respondSshAgentConfirm).toHaveBeenCalledWith(2, true);
+  });
+});

--- a/tests/e2e/wdio.conf.mjs
+++ b/tests/e2e/wdio.conf.mjs
@@ -229,6 +229,13 @@ export const config = {
           // cost for our UI.
           WEBKIT_DISABLE_COMPOSITING_MODE: "1",
           XDG_DATA_HOME: sandboxDataHome,
+          // The app takes a single-instance lock (lib.rs) keyed on the
+          // bundle identifier, which is shared by debug and release
+          // builds. Without this opt-out, a Clavix sitting in the
+          // maintainer's tray — or a not-yet-reaped binary from the
+          // previous spec — makes the instance under test exit at boot
+          // instead of opening a window.
+          CLAVIX_ALLOW_MULTIPLE_INSTANCES: "1",
         },
       },
     );


### PR DESCRIPTION
Two changes that landed together because they share the same trigger: several Clavix windows fighting over the SSH agent.

## `feat(single-instance)` — hand a second launch to the running Clavix

Launching Clavix while it was already running started a rival process. Two windows and two tray icons are the visible symptom; the real damage is the agent. `ssh_agent.rs` unlinks any stale socket before binding, so instance #2 starting its agent took over `$XDG_RUNTIME_DIR/clavix/agent.sock` — every `ssh`/`git` already pointing at `SSH_AUTH_SOCK` was then served by a vault that is very likely still locked, with nothing explaining where the keys went.

`tauri-plugin-single-instance` is registered ahead of every other plugin, as it requires. The callback reuses the tray's `raise_main_window`, which already handles hidden-to-tray and minimised windows and carries the GNOME/Mutter focus dance.

`CLAVIX_ALLOW_MULTIPLE_INSTANCES=1` opts out — debug and release share the bundle identifier, so a packaged Clavix in the tray would otherwise stop `pnpm tauri dev` from booting. The E2E suite sets it too, since it relaunches the binary between specs.

## `fix(ssh-agent)` — let Entrée answer the consent prompt

`showModal()` ran in the same synchronous block as `current = req`, and Svelte 5 flushes the `{#if current}` body on a microtask — so the dialog's focus algorithm ran against empty content and focus stayed on the `<dialog>` element. **Entrée did nothing at all**; reaching either button needed a Tab. Now the open awaits a tick, then focuses *Autoriser*.

Defaulting Entrée to approve has an obvious edge, so approvals are ignored for the first 300 ms after the dialog is on screen: long enough to absorb a keystroke already in flight, invisible to someone deliberately reaching for the button. Each queued prompt arms its own window, so a held Entrée cannot chain approvals across parallel signatures. Denials are never guarded.

## Tests

`SshConfirmDialog.svelte.test.ts` covers the focus target, the swallowed approval, the accepted one, immediate denial, and the queued-request re-arm. Verified by mutation: dropping the arming guard fails 2 of the 5.

## Not covered automatically

Neither the single-instance behaviour nor the keyboard path can be exercised in CI — one is about a *second process* against a live desktop session, the other about real focus and key autorepeat. Both have new checklists in `MANUAL_VALIDATION.md`, and **neither has been run yet**: this branch was written on a headless host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQ5iKps2Ae1D5R2Y4JETnC