### PR TITLE
test(e2e): cover the four surfaces v0.18.0 shipped untested

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -89,6 +89,10 @@ UI tests.
 | `share-cipher.spec.mjs`  | Personal cipher → org collection via `share_cipher_to_collection` IPC |
 | `lock-unlock.spec.mjs`   | Lock → unlock round-trip restores the vault              |
 | `auto-lock.spec.mjs`     | Idle window elapses → `UnlockForm` reappears             |
+| `custom-fields.spec.mjs` | Editor adds text + hidden fields; hidden value withheld by `get_cipher`, and an unrelated edit does not wipe them |
+| `bulk-selection.spec.mjs` | Ctrl-click selection → bulk trash through the confirmation; a plain click drops the selection |
+| `attachments.spec.mjs`   | Pick a file → upload → download → byte-for-byte compare; delete after confirmation |
+| `reprompt.spec.mjs`      | Wrong master password reveals nothing; dismissal reveals nothing; the row menu is gated too |
 
 Two env vars to iterate locally without recycling Docker each run:
 

--- a/tests/e2e/helpers/auth.mjs
+++ b/tests/e2e/helpers/auth.mjs
@@ -56,6 +56,29 @@ export async function loginAsSeededUser() {
  * Resolves as soon as rows are present, so it is a no-op when the gate
  * is off.
  */
+/**
+ * Re-sync from the toolbar and wait for the list to carry `name`.
+ *
+ * Items created through `invoke("create_cipher")` land in the Rust
+ * vault, not in the Svelte store the list paints from — the renderer
+ * only learns about them when *it* asks for a sync. A spec that
+ * creates fixtures over IPC and then looks for their rows has to press
+ * the same button a user would, or it waits twenty seconds for a row
+ * that was never going to appear.
+ */
+export async function syncAndWaitForRow(name) {
+  const syncButton = await $(".toolbar .tb-btn");
+  await syncButton.waitForClickable({ timeout: 15_000 });
+  await syncButton.click();
+  await showAllItems();
+  const row = await $(`.cipher-row*=${name}`);
+  await row.waitForClickable({
+    timeout: 30_000,
+    timeoutMsg: `no row for ${JSON.stringify(name)} after a toolbar sync`,
+  });
+  return row;
+}
+
 export async function showAllItems() {
   await browser.waitUntil(
     async () => {

--- a/tests/e2e/specs/attachments.spec.mjs
+++ b/tests/e2e/specs/attachments.spec.mjs
@@ -1,0 +1,182 @@
+// Attachments, driven from the detail panel.
+//
+// `src-tauri/tests/attachment_round_trip.rs` already proves the wire
+// format against a real Vaultwarden, but it drives `VaultwardenClient`
+// directly. What it cannot see is the half of the feature that lives in
+// the WebView: reading a picked file, base64-encoding it across the IPC
+// boundary in chunks, and getting the decrypted bytes back out. A
+// mistake there — the chunking, the encode, the `input.value` reset —
+// produces a corrupted file rather than an error, which is the kind of
+// failure a user discovers long after the fact.
+//
+// The file is handed to the input through a DataTransfer rather than
+// through WebDriver's file-upload path: the input is deliberately
+// `visually-hidden` (the button forwards the click), and "Element Send
+// Keys" on a hidden input is not something the WebKit driver owes us.
+// Building the FileList in the page is also closer to what the browser
+// itself does on a real pick.
+
+import { loginAsSeededUser, syncAndWaitForRow } from "../helpers/auth.mjs";
+
+const ITEM = "E2E attachment subject";
+const ITEM_DELETE = "E2E attachment delete subject";
+const FILE_NAME = "e2e-note.txt";
+// Non-ASCII on purpose: the payload travels as base64 through the IPC
+// boundary, and a naive charCode-based encode mangles anything above
+// U+00FF. Two lines, no trailing newline.
+const FILE_CONTENT = "clavix e2e — pièce jointe\nligne deux";
+
+async function createSubject(name) {
+  return browser.execute(async (itemName) => {
+    // @ts-expect-error — tauri injects this global
+    const { invoke } = window.__TAURI__.core;
+    const id = await invoke("create_cipher", {
+      input: {
+        cipherType: 1,
+        name: itemName,
+        folderId: null,
+        favorite: false,
+        notes: null,
+        organizationId: null,
+        collectionIds: [],
+        login: {
+          username: "attach@e2e.test",
+          password: "irrelevant",
+          uris: [],
+          totp: null,
+        },
+      },
+    });
+    await invoke("sync");
+    return id;
+  }, name);
+}
+
+/** Hand a file to the (deliberately hidden) picker. */
+async function pickFile(input, name, content) {
+  await browser.execute(
+    (el, fileName, fileContent) => {
+      const data = new DataTransfer();
+      data.items.add(new File([fileContent], fileName, { type: "text/plain" }));
+      el.files = data.files;
+      el.dispatchEvent(new Event("change", { bubbles: true }));
+    },
+    input,
+    name,
+    content,
+  );
+}
+
+describe("Attachments", () => {
+  before(async () => {
+    await loginAsSeededUser();
+  });
+
+  it("uploads a picked file and reads it back byte for byte", async () => {
+    const id = await createSubject(ITEM);
+    const row = await syncAndWaitForRow(ITEM);
+    await row.click();
+
+    // The section exists for any live item, empty or not — that is what
+    // makes "Joindre un fichier" reachable in the first place.
+    const attachButton = await $("button*=Joindre un fichier");
+    await attachButton.waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "the attachments section never rendered on a live item",
+    });
+
+    const input = await $(".attachment-add input[type='file']");
+    await pickFile(input, FILE_NAME, FILE_CONTENT);
+
+    // The row appears once the upload lands and the item is re-read.
+    const attachmentRow = await $(`.attachment-row*=${FILE_NAME}`);
+    await attachmentRow.waitForDisplayed({
+      timeout: 60_000,
+      timeoutMsg: "the uploaded attachment never appeared in the detail panel",
+    });
+
+    // Server-side proof plus a full decrypt: `download_attachment`
+    // returns base64, which must decode to exactly what was uploaded.
+    const check = await browser.execute(async (cipherId, expected) => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      await invoke("sync");
+      const detail = await invoke("get_cipher", { id: cipherId });
+      const attachment = detail.attachments[0];
+      if (!attachment) return { error: "no attachment on the synced cipher" };
+
+      const base64 = await invoke("download_attachment", {
+        cipherId,
+        attachmentId: attachment.id,
+      });
+      const binary = atob(base64);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+      const roundTripped = new TextDecoder().decode(bytes);
+      return {
+        fileName: attachment.fileName,
+        size: attachment.size,
+        matches: roundTripped === expected,
+        roundTripped,
+      };
+    }, id, FILE_CONTENT);
+
+    if (check.error) throw new Error(check.error);
+    if (check.fileName !== FILE_NAME) {
+      throw new Error(`attachment name came back as ${JSON.stringify(check.fileName)}`);
+    }
+    if (!check.matches) {
+      throw new Error(
+        `attachment content did not survive the round trip: ${JSON.stringify(check.roundTripped)}`,
+      );
+    }
+    // Ciphertext, so strictly larger than the plaintext: header plus a
+    // padding block. Guards against a zero-length upload passing the
+    // content check by decoding to an empty string on both sides.
+    if (!(check.size > 0)) {
+      throw new Error(`the server recorded a size of ${check.size}`);
+    }
+  });
+
+  it("deletes an attachment after confirmation", async () => {
+    const id = await createSubject(ITEM_DELETE);
+    const row = await syncAndWaitForRow(ITEM_DELETE);
+    await row.click();
+
+    const input = await $(".attachment-add input[type='file']");
+    await input.waitForExist({ timeout: 15_000 });
+    await pickFile(input, FILE_NAME, FILE_CONTENT);
+
+    const attachmentRow = await $(`.attachment-row*=${FILE_NAME}`);
+    await attachmentRow.waitForDisplayed({ timeout: 60_000 });
+
+    // The trash icon at the end of the row.
+    const deleteButton = await attachmentRow.$('button[title="Supprimer"]');
+    await deleteButton.click();
+
+    const dialog = await $("dialog.confirm-dialog");
+    await dialog.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "deleting an attachment did not ask for confirmation",
+    });
+    const confirmButton = await dialog.$$(".confirm-actions button")[1];
+    await confirmButton.click();
+
+    await browser.waitUntil(
+      async () => {
+        const count = await browser.execute(async (cipherId) => {
+          // @ts-expect-error
+          const { invoke } = window.__TAURI__.core;
+          await invoke("sync");
+          const detail = await invoke("get_cipher", { id: cipherId });
+          return detail.attachments.length;
+        }, id);
+        return count === 0;
+      },
+      {
+        timeout: 30_000,
+        timeoutMsg: "the attachment is still on the cipher after a confirmed delete",
+      },
+    );
+  });
+});

--- a/tests/e2e/specs/bulk-selection.spec.mjs
+++ b/tests/e2e/specs/bulk-selection.spec.mjs
@@ -1,0 +1,172 @@
+// Multi-selection in the item list, driven through the UI.
+//
+// The selection is the one piece of vault state that lives in the page
+// rather than in the store, and it is only reachable through modifier
+// clicks — there is no checkbox column. That makes it invisible to
+// every other layer of tests: the vitest suites cover the pure filter
+// helpers, and the IPC-level specs never touch a row. What can break
+// here is exactly what no other test would notice — a plain click that
+// forgets to drop the selection, a Shift range computed against the
+// unfiltered list, or a bulk delete that fires on ids the current
+// filter no longer shows.
+//
+// Ctrl-click is dispatched as a synthetic MouseEvent rather than
+// through the WebDriver key-down/click dance: what we are testing is
+// the component's handling of `event.ctrlKey`, and going through the
+// real keyboard adds a WebKitGTK focus dependency that has nothing to
+// do with the behaviour under test.
+
+import { loginAsSeededUser, syncAndWaitForRow } from "../helpers/auth.mjs";
+
+const ITEMS = ["E2E bulk one", "E2E bulk two", "E2E bulk three"];
+const PLAIN_ITEMS = ["E2E plain one", "E2E plain two"];
+
+/** Create the three dedicated ciphers this spec operates on. */
+async function seedBulkItems(names) {
+  return browser.execute(async (itemNames) => {
+    // @ts-expect-error — tauri injects this global
+    const { invoke } = window.__TAURI__.core;
+    const ids = [];
+    for (const name of itemNames) {
+      ids.push(
+        await invoke("create_cipher", {
+          input: {
+            cipherType: 1,
+            name,
+            folderId: null,
+            favorite: false,
+            notes: null,
+            organizationId: null,
+            collectionIds: [],
+            login: {
+              username: "bulk@e2e.test",
+              password: "irrelevant",
+              uris: [],
+              totp: null,
+            },
+          },
+        }),
+      );
+    }
+    await invoke("sync");
+    return ids;
+  }, names);
+}
+
+async function clickRow(name, modifiers = {}) {
+  const row = await $(`.cipher-row*=${name}`);
+  await row.waitForClickable({ timeout: 15_000 });
+  await browser.execute(
+    (el, mods) => el.dispatchEvent(new MouseEvent("click", { bubbles: true, ...mods })),
+    row,
+    modifiers,
+  );
+}
+
+/** Ids the server currently reports as trashed. */
+async function trashedIds() {
+  return browser.execute(async () => {
+    // @ts-expect-error
+    const { invoke } = window.__TAURI__.core;
+    const summary = await invoke("sync");
+    return summary.ciphers.filter((c) => c.deletedDate).map((c) => c.id);
+  });
+}
+
+describe("Bulk selection", () => {
+  // One login per spec file — WDIO reuses a single browser session.
+  before(async () => {
+    await loginAsSeededUser();
+  });
+
+  it("selects with Ctrl-click and moves the selection to the trash", async () => {
+    const ids = await seedBulkItems(ITEMS);
+    // Items created over IPC live in the Rust vault; the list only
+    // learns about them when the renderer syncs.
+    await syncAndWaitForRow(ITEMS[0]);
+
+    // No selection, no bar: it must not take a row of vertical space
+    // for an action nobody asked for.
+    const bar = await $(".selection-bar");
+    if (await bar.isExisting()) {
+      throw new Error("the selection bar is on screen with nothing selected");
+    }
+
+    await clickRow(ITEMS[0], { ctrlKey: true });
+    await clickRow(ITEMS[1], { ctrlKey: true });
+
+    await bar.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "selection bar never appeared after two Ctrl-clicks",
+    });
+    const count = await $(".selection-count").getText();
+    if (!count.includes("2")) {
+      throw new Error(`expected the bar to report 2 selected, got: ${count}`);
+    }
+
+    // Delete → the shared confirmation dialog, which must be answered
+    // before anything is written.
+    const deleteButton = await $(".selection-bar button.danger");
+    await deleteButton.click();
+
+    const dialog = await $("dialog.confirm-dialog");
+    await dialog.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "bulk delete did not raise a confirmation",
+    });
+    const body = await dialog.$(".confirm-body").getText();
+    if (!body.includes("2")) {
+      throw new Error(`the confirmation should name the count, got: ${body}`);
+    }
+
+    // Second button in the row is the confirm one; the first is Annuler,
+    // which is where focus deliberately lands.
+    const confirmButton = await dialog.$$(".confirm-actions button")[1];
+    await confirmButton.click();
+
+    await browser.waitUntil(
+      async () => {
+        const trashed = await trashedIds();
+        return trashed.includes(ids[0]) && trashed.includes(ids[1]);
+      },
+      {
+        timeout: 30_000,
+        timeoutMsg: "the two selected items never reached the trash on the server",
+      },
+    );
+
+    // The untouched third item must still be live — a bulk action that
+    // quietly widened its own scope is the failure mode that matters.
+    const stillLive = await browser.execute(async (id) => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      const summary = await invoke("sync");
+      const c = summary.ciphers.find((c) => c.id === id);
+      return c ? c.deletedDate === null : null;
+    }, ids[2]);
+    if (stillLive !== true) {
+      throw new Error(
+        `the unselected item should be untouched, deletedDate check returned ${JSON.stringify(stillLive)}`,
+      );
+    }
+  });
+
+  it("drops the selection on a plain click", async () => {
+    await seedBulkItems(PLAIN_ITEMS);
+    await syncAndWaitForRow(PLAIN_ITEMS[0]);
+
+    await clickRow(PLAIN_ITEMS[0], { ctrlKey: true });
+    const bar = await $(".selection-bar");
+    await bar.waitForDisplayed({ timeout: 10_000 });
+
+    // A plain click opens the item and clears the ticks. Without this,
+    // a coche left over from three filters ago rides along into the
+    // next bulk delete.
+    await clickRow(PLAIN_ITEMS[1]);
+    await bar.waitForDisplayed({
+      reverse: true,
+      timeout: 10_000,
+      timeoutMsg: "the selection survived a plain click",
+    });
+  });
+});

--- a/tests/e2e/specs/custom-fields.spec.mjs
+++ b/tests/e2e/specs/custom-fields.spec.mjs
@@ -1,0 +1,211 @@
+// Custom fields, added through the editor and read back from the
+// server.
+//
+// The chain under test is the one that used to lose data: the editor
+// binds the rows, `payloadToRust` drops the empty ones, Rust encrypts
+// name and value under the item key, and the cipher PUT — which
+// replaces the server's copy wholesale — has to carry them. A body
+// that omits `fields` deletes them silently, which is precisely the
+// bug this suite exists to keep out.
+//
+// The hidden-field assertion is the interesting one: `get_cipher` must
+// withhold the value (presence only, like every other secret) while
+// `reveal_field("custom:<index>")` hands it over on demand. Getting
+// that backwards would be invisible in the UI and would put a secret
+// back into long-lived WebView state.
+
+import { loginAsSeededUser, syncAndWaitForRow } from "../helpers/auth.mjs";
+
+const ITEM = "E2E custom fields subject";
+const ITEM_KEPT = "E2E custom fields kept";
+const TEXT_FIELD = { name: "Account ID", value: "AC-42" };
+const HIDDEN_FIELD = { name: "Recovery", value: "code-123" };
+
+async function createSubject(name) {
+  return browser.execute(async (itemName) => {
+    // @ts-expect-error — tauri injects this global
+    const { invoke } = window.__TAURI__.core;
+    const id = await invoke("create_cipher", {
+      input: {
+        cipherType: 1,
+        name: itemName,
+        folderId: null,
+        favorite: false,
+        notes: null,
+        organizationId: null,
+        collectionIds: [],
+        login: {
+          username: "fields@e2e.test",
+          password: "irrelevant",
+          uris: [],
+          totp: null,
+        },
+      },
+    });
+    await invoke("sync");
+    return id;
+  }, name);
+}
+
+/**
+ * Fill the last custom-field row of the editor.
+ *
+ * A row is `select`, then two inputs: name, then value. The value one
+ * is `type="password"` for a hidden field and `type="text"` otherwise,
+ * so it is addressed by position rather than by type.
+ */
+async function fillLastRow(kind, field) {
+  const rows = await $$(".custom-field-row");
+  const row = rows[rows.length - 1];
+
+  if (kind !== 0) {
+    await row.$("select").selectByAttribute("value", String(kind));
+  }
+  const inputs = await row.$$("input");
+  await inputs[0].setValue(field.name);
+  await inputs[1].setValue(field.value);
+}
+
+describe("Custom fields", () => {
+  // One login for the whole file: WDIO keeps a single browser session
+  // per spec, so a second `loginAsSeededUser` would wait forever on a
+  // login form that is no longer on screen.
+  before(async () => {
+    await loginAsSeededUser();
+  });
+
+  it("survives a save and keeps hidden values out of get_cipher", async () => {
+    const id = await createSubject(ITEM);
+    const row = await syncAndWaitForRow(ITEM);
+    await row.click();
+
+    const editButton = await $("button=Éditer");
+    await editButton.waitForClickable({ timeout: 10_000 });
+    await editButton.click();
+
+    const editor = await $(".editor-panel");
+    await editor.waitForDisplayed({ timeout: 10_000 });
+
+    const addField = await $("button*=Ajouter un champ");
+    await addField.waitForClickable({ timeout: 10_000 });
+
+    await addField.click();
+    await fillLastRow(0, TEXT_FIELD);
+    await addField.click();
+    await fillLastRow(1, HIDDEN_FIELD);
+
+    const submit = await editor.$('button[type="submit"]');
+    await submit.click();
+    await editor.waitForExist({
+      reverse: true,
+      timeout: 20_000,
+      timeoutMsg: "editor did not close after saving custom fields",
+    });
+
+    // Read the item back through a fresh sync, so this asserts on what
+    // Vaultwarden stored rather than on local state.
+    const stored = await browser.execute(async (cipherId) => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      await invoke("sync");
+      const detail = await invoke("get_cipher", { id: cipherId });
+      const revealed = await invoke("reveal_field", {
+        id: cipherId,
+        field: "custom:1",
+      });
+      return { fields: detail.fields, revealed };
+    }, id);
+
+    if (stored.fields.length !== 2) {
+      throw new Error(
+        `expected 2 custom fields after save, got ${JSON.stringify(stored.fields)}`,
+      );
+    }
+
+    const [text, hidden] = stored.fields;
+    if (text.name !== TEXT_FIELD.name || text.value !== TEXT_FIELD.value) {
+      throw new Error(`text field round-tripped wrong: ${JSON.stringify(text)}`);
+    }
+    if (hidden.name !== HIDDEN_FIELD.name) {
+      throw new Error(`hidden field name round-tripped wrong: ${JSON.stringify(hidden)}`);
+    }
+    if (hidden.hidden !== true || hidden.value !== null) {
+      throw new Error(
+        `a hidden field must reach the WebView without its value, got ${JSON.stringify(hidden)}`,
+      );
+    }
+    if (stored.revealed !== HIDDEN_FIELD.value) {
+      throw new Error(
+        `reveal_field("custom:1") returned ${JSON.stringify(stored.revealed)}`,
+      );
+    }
+  });
+
+  it("keeps the fields when the item is edited again", async () => {
+    // The regression in one line: open an item that has custom fields,
+    // change something unrelated, save. The PUT replaces the server's
+    // copy, so a body that forgot the fields would wipe them here.
+    const id = await createSubject(ITEM_KEPT);
+
+    await browser.execute(async (cipherId, field, itemName) => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      await invoke("update_cipher", {
+        cipherId,
+        input: {
+          cipherType: 1,
+          name: itemName,
+          folderId: null,
+          favorite: false,
+          notes: null,
+          organizationId: null,
+          collectionIds: [],
+          login: {
+            username: "fields@e2e.test",
+            password: "irrelevant",
+            uris: [],
+            totp: null,
+          },
+          fields: [{ kind: 0, name: field.name, value: field.value, linkedId: null }],
+          reprompt: false,
+        },
+      });
+    }, id, TEXT_FIELD, ITEM_KEPT);
+
+    const row = await syncAndWaitForRow(ITEM_KEPT);
+    await row.click();
+
+    const editButton = await $("button=Éditer");
+    await editButton.waitForClickable({ timeout: 10_000 });
+    await editButton.click();
+
+    const editor = await $(".editor-panel");
+    await editor.waitForDisplayed({ timeout: 10_000 });
+
+    // The editor must have loaded the existing row.
+    const rows = await $$(".custom-field-row");
+    if (rows.length !== 1) {
+      throw new Error(`editor showed ${rows.length} custom field rows, expected 1`);
+    }
+
+    // Touch something else entirely, then save.
+    const favorite = await editor.$(".checkbox-row input[type='checkbox']");
+    await favorite.click();
+    await editor.$('button[type="submit"]').click();
+    await editor.waitForExist({ reverse: true, timeout: 20_000 });
+
+    const after = await browser.execute(async (cipherId) => {
+      // @ts-expect-error
+      const { invoke } = window.__TAURI__.core;
+      await invoke("sync");
+      const detail = await invoke("get_cipher", { id: cipherId });
+      return detail.fields;
+    }, id);
+
+    if (after.length !== 1 || after[0].value !== TEXT_FIELD.value) {
+      throw new Error(
+        `an unrelated edit wiped the custom fields: ${JSON.stringify(after)}`,
+      );
+    }
+  });
+});

--- a/tests/e2e/specs/reprompt.spec.mjs
+++ b/tests/e2e/specs/reprompt.spec.mjs
@@ -1,0 +1,164 @@
+// The per-item master-password gate.
+//
+// This is the one new surface whose whole value is that it refuses
+// something, so a test that only checks the happy path would miss the
+// point entirely: what matters is that a wrong password reveals
+// nothing, and that dismissing the prompt leaves the secret hidden.
+//
+// The gate lives in the page rather than in the detail panel precisely
+// so every entry point honours it, so the second case here goes in
+// through the row context menu — a path that has its own copy of the
+// "reveal a secret" logic and would be the natural place for the gate
+// to be forgotten.
+
+import { loginAsSeededUser, syncAndWaitForRow } from "../helpers/auth.mjs";
+
+const ITEM = "E2E reprompt subject";
+const PASSWORD = "s3cret-under-guard";
+const MASTER = "correct-horse-battery-staple";
+
+async function createGuardedItem(name) {
+  return browser.execute(
+    async (itemName, password) => {
+      // @ts-expect-error — tauri injects this global
+      const { invoke } = window.__TAURI__.core;
+      const id = await invoke("create_cipher", {
+        input: {
+          cipherType: 1,
+          name: itemName,
+          folderId: null,
+          favorite: false,
+          notes: null,
+          organizationId: null,
+          collectionIds: [],
+          login: { username: "guard@e2e.test", password, uris: [], totp: null },
+          fields: [],
+          reprompt: true,
+        },
+      });
+      await invoke("sync");
+      return id;
+    },
+    name,
+    PASSWORD,
+  );
+}
+
+/** Create a guarded item, sync the list, open it, return its row. */
+async function openGuardedItem(name) {
+  await createGuardedItem(name);
+  const row = await syncAndWaitForRow(name);
+  await row.click();
+  return row;
+}
+
+/** The eye toggle on the password row of the detail panel. */
+async function revealButton() {
+  const button = await $('.detail-field button[title="Afficher"]');
+  await button.waitForClickable({ timeout: 15_000 });
+  return button;
+}
+
+describe("Master-password reprompt", () => {
+  before(async () => {
+    await loginAsSeededUser();
+  });
+
+  it("refuses to reveal on a wrong password and reveals on the right one", async () => {
+    await openGuardedItem(`${ITEM} A`);
+
+    await (await revealButton()).click();
+
+    const dialog = await $("dialog.reprompt-dialog");
+    await dialog.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "revealing a flagged item did not ask for the master password",
+    });
+
+    // Wrong password: the dialog stays, says so, and nothing is shown.
+    const input = await dialog.$('input[type="password"]');
+    await input.setValue("not-the-master-password");
+    await dialog.$('button[type="submit"]').click();
+
+    const error = await dialog.$(".reprompt-error");
+    await error.waitForDisplayed({
+      timeout: 15_000,
+      timeoutMsg: "a wrong master password was accepted silently",
+    });
+    if (!(await dialog.isDisplayed())) {
+      throw new Error("the prompt closed on a wrong password");
+    }
+    const bodyText = await $(".cipher-detail").getText();
+    if (bodyText.includes(PASSWORD)) {
+      throw new Error("the password was on screen despite a failed reprompt");
+    }
+
+    // Right password: the dialog closes and the value appears.
+    await input.setValue(MASTER);
+    await dialog.$('button[type="submit"]').click();
+    await dialog.waitForDisplayed({
+      reverse: true,
+      timeout: 15_000,
+      timeoutMsg: "the prompt stayed up after the correct master password",
+    });
+
+    await browser.waitUntil(
+      async () => (await $(".cipher-detail").getText()).includes(PASSWORD),
+      {
+        timeout: 15_000,
+        timeoutMsg: "the password never appeared after a successful reprompt",
+      },
+    );
+  });
+
+  it("reveals nothing when the prompt is dismissed", async () => {
+    await openGuardedItem(`${ITEM} B`);
+
+    await (await revealButton()).click();
+    const dialog = await $("dialog.reprompt-dialog");
+    await dialog.waitForDisplayed({ timeout: 10_000 });
+
+    // Annuler is the first button and where focus deliberately lands.
+    await dialog.$("button.secondary").click();
+    await dialog.waitForDisplayed({ reverse: true, timeout: 10_000 });
+
+    const detail = await $(".cipher-detail").getText();
+    if (detail.includes(PASSWORD)) {
+      throw new Error("dismissing the prompt still revealed the password");
+    }
+    // The toggle must not have flipped either — a dismissed prompt
+    // leaves the row exactly as it was.
+    const stillHidden = await $('.detail-field button[title="Afficher"]');
+    if (!(await stillHidden.isExisting())) {
+      throw new Error("the reveal toggle flipped despite the refusal");
+    }
+  });
+
+  it("guards the row context menu too, not just the detail panel", async () => {
+    const row = await openGuardedItem(`${ITEM} C`);
+
+    // Right-click the row: the menu offers "Copier le mot de passe"
+    // only once the decrypted detail is known to carry one.
+    await browser.execute(
+      (el) => el.dispatchEvent(new MouseEvent("contextmenu", { bubbles: true })),
+      row,
+    );
+
+    const menu = await $(".ctx-menu");
+    await menu.waitForDisplayed({ timeout: 10_000 });
+
+    const copyPassword = await menu.$("button*=mot de passe");
+    await copyPassword.waitForClickable({
+      timeout: 15_000,
+      timeoutMsg: "the context menu never offered the password copy",
+    });
+    await copyPassword.click();
+
+    const dialog = await $("dialog.reprompt-dialog");
+    await dialog.waitForDisplayed({
+      timeout: 10_000,
+      timeoutMsg: "copying from the row menu bypassed the reprompt",
+    });
+    await dialog.$("button.secondary").click();
+  });
+});


### PR DESCRIPTION
v0.18.0 shipped attachments, custom fields, multi-selection and the master-password reprompt with **no UI-level coverage**. The vitest suites reach pure helpers and a couple of components; the existing specs drive IPC. Everything between a click and an `invoke` was unwatched. This closes that.

| Spec | Cases | What it is actually for |
|---|---|---|
| `custom-fields` | 2 | The regression that motivated the feature work: an unrelated edit must not wipe the fields. Also pins the secret rule — a hidden value reaches the WebView withheld by `get_cipher` and is fetchable only via `reveal_field("custom:<i>")`. |
| `attachments` | 2 | `attachment_round_trip.rs` proves the wire format against a real Vaultwarden but drives the client directly. This covers the other half: picked file → chunked base64 across IPC → decrypted bytes back, compared byte for byte. |
| `bulk-selection` | 2 | A plain click must drop the selection, or a tick left over from three filters ago rides along into the next bulk delete. The unselected third item is asserted untouched. |
| `reprompt` | 3 | The surface whose whole value is refusing: a wrong password and a dismissal must both reveal nothing. The row context menu is checked separately — it has its own copy of the reveal path and is where the gate would be forgotten. |

The attachment fixture content carries an em dash and accents deliberately: a `charCodeAt`-based encode mangles anything above U+00FF if the chunking is wrong, and that failure produces a corrupted file rather than an error.

## Two things the first run taught

Both now live in `helpers/auth.mjs`:

- **`invoke("sync")` does not repaint the list.** Fixtures created over IPC land in the Rust vault; the Svelte store only learns about them when the renderer syncs. `syncAndWaitForRow` presses the toolbar button a user would. Without it a spec waits twenty seconds for a row that was never going to appear.
- **WDIO keeps one browser session per spec file**, so `loginAsSeededUser` belongs in `before()` — calling it per test blocks on a login form that is no longer on screen.

## Testing

Full suite locally with the CI's own per-spec reset: **20 spec files pass** (`E2E_PER_SPEC_RESET=1`, ~2m20 plus reset time). Each new spec also runs green in isolation against a freshly seeded container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbsxEfw1BY5L2Q4dT7FV11