### PR TITLE
chore(deps-npm): raise undici and brace-expansion security floors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<1.1.16: ^1.1.16
-  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: ^2.1.4
   cookie@<0.7.0: ^0.7.0
   cross-spawn@<7.0.5: ^7.0.6
   esbuild@<0.25.0: ^0.25.0
@@ -16,6 +16,9 @@ overrides:
   serialize-javascript@<7.0.5: ^7.0.5
   tar-fs@>=2.0.0 <2.1.4: ^2.1.4
   tmp@<0.2.6: ^0.2.6
+  undici@<6.28.0: ^6.28.0
+  undici@>=7.0.0 <7.29.0: ^7.29.0
+  undici@>=8.0.0 <8.9.0: ^8.9.0
   uuid@<14.0.0: ^14.0.0
   ws@<8.21.0: ^8.21.0
 
@@ -551,6 +554,12 @@ packages:
     resolution: {integrity: sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
 
   '@rolldown/binding-darwin-arm64@1.2.2':
     resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
@@ -1132,11 +1141,11 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2565,8 +2574,8 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+  tar-fs@2.1.5:
+    resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
 
   tar-fs@3.1.3:
     resolution: {integrity: sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==}
@@ -2670,12 +2679,12 @@ packages:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.28.0:
-    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.9.0:
-    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
@@ -2889,6 +2898,18 @@ packages:
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.2:
+    resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3349,6 +3370,9 @@ snapshots:
       - bare-buffer
       - react-native-b4a
       - supports-color
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    optional: true
 
   '@rolldown/binding-darwin-arm64@1.2.2':
     optional: true
@@ -3948,12 +3972,12 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -4011,7 +4035,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -4749,7 +4773,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 8.9.0
+      undici: 8.10.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -4892,15 +4916,15 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minipass@7.1.3: {}
 
@@ -5160,9 +5184,9 @@ snapshots:
       progress: 2.0.3
       proxy-from-env: 1.1.0
       rimraf: 3.0.2
-      tar-fs: 2.1.4
+      tar-fs: 2.1.5
       unbzip2-stream: 1.4.3
-      ws: 8.21.0
+      ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -5252,6 +5276,7 @@ snapshots:
       '@oxc-project/types': 0.142.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.2
       '@rolldown/binding-darwin-arm64': 1.2.2
       '@rolldown/binding-darwin-x64': 1.2.2
       '@rolldown/binding-freebsd-x64': 1.2.2
@@ -5464,7 +5489,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tar-fs@2.1.4:
+  tar-fs@2.1.5:
     dependencies:
       chownr: 1.1.4
       mkdirp-classic: 0.5.3
@@ -5584,9 +5609,9 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
-  undici@8.9.0: {}
+  undici@8.10.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -5804,6 +5829,9 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.0: {}
+
+  ws@8.21.2:
+    optional: true
 
   xml-name-validator@5.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,14 +2,16 @@
 # Moved here from the `pnpm.overrides` field in package.json, which pnpm 11+
 # no longer reads (see https://pnpm.io/settings).
 overrides:
-  # GHSA-3jxr-9vmj-r5cp, backported to both lines the wdio chain pulls in.
-  # Do NOT collapse these into `brace-expansion@<5.0.8: ^5.0.8` to also cover
-  # GHSA-mh99-v99m-4gvg: 5.x exports `{ expand }` instead of the callable
-  # default, so every minimatch <= 6 dies with "expand is not a function".
-  # Only minimatch >= 9.0.6 speaks that API, and getting there means moving
-  # @wdio off v7 — see the follow-up issue.
-  brace-expansion@<1.1.16: ^1.1.16
-  brace-expansion@>=2.0.0 <2.1.2: ^2.1.2
+  # GHSA-3jxr-9vmj-r5cp, then GHSA-mh99-v99m-4gvg and GHSA-rgw5-rvv9-x895
+  # (the latter bypasses the former's mitigation), backported to both lines
+  # the wdio chain pulls in. Floors track the highest patched version of the
+  # three: 1.1.18 and 2.1.4.
+  # Do NOT collapse these into `brace-expansion@<5.0.8: ^5.0.8`: 5.x exports
+  # `{ expand }` instead of the callable default, so every minimatch <= 6 dies
+  # with "expand is not a function". Only minimatch >= 9.0.6 speaks that API,
+  # and getting there means moving @wdio off v7 — see the follow-up issue.
+  brace-expansion@<1.1.18: ^1.1.18
+  brace-expansion@>=2.0.0 <2.1.4: ^2.1.4
   cookie@<0.7.0: ^0.7.0
   cross-spawn@<7.0.5: ^7.0.6
   esbuild@<0.25.0: ^0.25.0
@@ -19,5 +21,11 @@ overrides:
   serialize-javascript@<7.0.5: ^7.0.5
   tar-fs@>=2.0.0 <2.1.4: ^2.1.4
   tmp@<0.2.6: ^0.2.6
+  # GHSA-4cwx-7wf7-3272 (high) plus four medium cache/cookie/CRLF advisories,
+  # all fixed on the same three release lines. The wdio chain carries 6.x
+  # (webdriver) and 7.x (cheerio), vitest/jsdom carries 8.x — pin each.
+  undici@<6.28.0: ^6.28.0
+  undici@>=7.0.0 <7.29.0: ^7.29.0
+  undici@>=8.0.0 <8.9.0: ^8.9.0
   uuid@<14.0.0: ^14.0.0
   ws@<8.21.0: ^8.21.0


### PR DESCRIPTION
Clears the **five open Dependabot alerts** on `undici`, plus **four high-severity `pnpm audit` findings** on `brace-expansion` that the Dependabot page does not surface.

## undici — 5 alerts (1 high, 4 medium)

| GHSA | Severity | Issue |
|---|---|---|
| `GHSA-4cwx-7wf7-3272` | **high** | cross-user info disclosure + parse-time crash via degenerate private cache directives |
| `GHSA-8xcm-r25x-g524` | medium | downstream response desync via retry interceptor |
| `GHSA-v3r7-h72x-cjcm` | medium | cookie attribute injection via unsanitized `domain` |
| `GHSA-jr45-8vmc-qm54` | medium | info disclosure via whitespace around `=` in `Cache-Control` |
| `GHSA-m8rv-5g2x-5cg5` | medium | CRLF injection via blob body `type` |

The vulnerable copy was `7.28.0`, pulled by `cheerio` ← `webdriverio` ← `@wdio/*` — **devDependencies only**, so nothing reached the shipped Tauri binary. Real-world exposure for users was nil; this is CI hygiene.

The 6.x (`webdriver`) and 8.x (`jsdom`) copies already sat on their line's patched release, which is why only one alert fired per advisory. All three lines are now pinned so resolution can't drift back under a floor. Resolves to **6.28.0 / 7.29.0 / 8.10.0**.

## brace-expansion — 4 high, not shown by Dependabot

`GHSA-mh99-v99m-4gvg` and `GHSA-rgw5-rvv9-x895` (the latter bypasses the former's mitigation), DoS/OOM via unbounded expansion, on both `1.1.16` and `2.1.2` via `@wdio/cli`.

The existing overrides only covered the earlier `GHSA-3jxr-9vmj-r5cp`, and their `^1.1.16` / `^2.1.2` floors clear neither new advisory. Raised to **1.1.18 / 2.1.4**.

The "do NOT collapse into `^5.0.8`" warning still holds and is untouched: 5.x exports `{ expand }` instead of the callable default, so every `minimatch <= 6` dies with `expand is not a function`. That needs `minimatch >= 9.0.6`, which means moving `@wdio` off v7 — out of scope here.

## Verification

- `pnpm audit` → **No known vulnerabilities found** (was 4 high)
- `pnpm run test` → 182 tests / 14 files, all pass
- `pnpm run build` → green
- `pnpm run check` → 1196 files, 0 errors, 0 warnings

⚠️ `pnpm run test:e2e` was **not** run locally — it needs the debug Tauri binary, and the wdio chain is exactly what these bumps touch. CI is the real check on that front.

Lockfile + overrides only; no source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPNpe9EXM6D6735scho1DL