### PR TITLE
ci: gate the npm tree on pnpm audit, as cargo audit already gates Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,52 @@ jobs:
       - name: Unit tests (vitest)
         run: pnpm test
 
+      # The npm counterpart to the `cargo audit` step above, which had no
+      # equivalent until now. That gap was not theoretical: on 2026-08-04 the
+      # Dependabot alert page listed five `undici` advisories while `pnpm audit`
+      # found four more HIGH findings on `brace-expansion` that Dependabot never
+      # surfaced, because a stale override floor in pnpm-workspace.yaml kept the
+      # package from being re-flagged (see #245).
+      #
+      # Split in two on purpose:
+      #
+      # `--prod` is absolute — nothing vulnerable ships in the Tauri binary.
+      # If it ever goes red, users are exposed.
+      #
+      # The full-tree pass reaches the dev chain (@wdio/*, jsdom, vite) where
+      # both of the 2026-08-04 findings actually lived.
+      #
+      # Two pnpm audit flags look like they belong here and MUST NOT be used;
+      # both were measured against a deliberately re-pinned brace-expansion
+      # 2.1.2 tree that plain `pnpm audit` correctly failed with exit 1:
+      #
+      #   --ignore-unfixable   exits 0 and prints nothing on that tree. It
+      #                        treats an advisory as unfixable when an override
+      #                        pins the version — and this repo pins a dozen of
+      #                        them right below, so the flag blinds the gate
+      #                        exactly where the gate is needed.
+      #
+      #   --ignore <CVE>       always exits 0, even for a CVE that does not
+      #                        exist (tested with CVE-0000-0000). It is not a
+      #                        filter: it WRITES the id into `auditConfig` in
+      #                        pnpm-workspace.yaml and reports success. Passing
+      #                        it in CI would turn this step into a no-op and
+      #                        mutate a tracked file on the runner.
+      #
+      # `--ignore-registry-errors` per pnpm's own CI guidance: a flaky npm
+      # registry must not fail an unrelated build.
+      #
+      # To silence a genuinely unactionable advisory, hand-edit
+      # `auditConfig.ignoreCves` in pnpm-workspace.yaml and document why,
+      # mirroring the `--ignore RUSTSEC-...` comment on the cargo audit step.
+      # Config-based ignores keep the exit code honest: a tree with one ignored
+      # and one live finding still fails. Never reach for the CLI flag.
+      - name: pnpm audit (production tree)
+        run: pnpm audit --prod --ignore-registry-errors
+
+      - name: pnpm audit (full tree)
+        run: pnpm audit --ignore-registry-errors
+
   e2e:
     name: E2E (Tauri + WebdriverIO)
     runs-on: ubuntu-24.04


### PR DESCRIPTION
The Rust job has run `cargo audit` since early on. The npm side had no equivalent — and that gap is what let today's findings hide.

On 2026-08-04 the Dependabot alert page listed five `undici` advisories, while `pnpm audit` found **four more HIGH findings on `brace-expansion` that Dependabot never surfaced**. The backported `1.1.18` / `2.1.4` releases had shipped weeks earlier and nothing told us; #218 was still open on the premise that no backport existed. This step would have gone red the day those backports landed.

## What is added

```yaml
- name: pnpm audit (production tree)
  run: pnpm audit --prod --ignore-registry-errors

- name: pnpm audit (full tree)
  run: pnpm audit --ignore-registry-errors
```

`--prod` is absolute: nothing vulnerable ships in the Tauri binary. The full-tree pass reaches the dev chain (`@wdio/*`, `jsdom`, `vite`) where both of today's findings actually lived.

## Two flags deliberately absent

This PR started out using `--ignore-unfixable`, which reads as the obvious way to avoid a chronically red build. It was dropped after measuring it. Both flags below were tested against a deliberately re-pinned `brace-expansion@2.1.2` tree that plain `pnpm audit` correctly fails with exit 1:

| Flag | Behaviour on a known-vulnerable tree |
|---|---|
| `--ignore-unfixable` | **exit 0, prints nothing.** Treats an advisory as unfixable when an override pins the version — and `pnpm-workspace.yaml` pins a dozen. It blinds the gate exactly where the gate is needed. |
| `--ignore <CVE>` | **exit 0 always**, even for `CVE-0000-0000`, which does not exist. It is not a filter: it *writes* the id into `auditConfig` in `pnpm-workspace.yaml` and reports success. In CI it would be a no-op that also mutates a tracked file on the runner. |

The escape hatch is a hand-edited `auditConfig.ignoreCves`, documented in place like the `--ignore RUSTSEC-2023-0071` comment on the cargo step. Config-based ignores keep the exit code honest — a tree with one ignored and one live finding still fails.

## Trade-off

A genuinely unfixable dev-chain advisory will now hold CI red until it is fixed upstream or explicitly ignored in config. That is the same deal the Rust job has always had, and the alternative — a flag that silently passes — is what this PR exists to avoid.

## Verification

- Both steps exit 0 on the current tree, and leave no tracked file modified.
- Plain `pnpm audit` exits 1 on the re-pinned `2.1.2` tree (2 high), confirming the gate actually bites.
- Workflow YAML parses; no tabs introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPNpe9EXM6D6735scho1DL