### PR TITLE
chore(deps): raise the js-yaml audit floor and add one for nanoid

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,10 @@ overrides:
   cookie@<0.7.0: ^0.7.0
   cross-spawn@<7.0.5: ^7.0.6
   esbuild@<0.25.0: ^0.25.0
-  js-yaml@<4.3.0: ^4.3.0
+  js-yaml@<4.3.1: ^4.3.1
   kysely@<0.28.17: ^0.28.17
   minimatch@<3.1.3: ^3.1.3
+  nanoid@<3.3.17: ^3.3.17
   serialize-javascript@<7.0.5: ^7.0.5
   tar-fs@>=2.0.0 <2.1.4: ^2.1.4
   tmp@<0.2.6: ^0.2.6
@@ -1865,8 +1866,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@30.0.1:
@@ -2102,8 +2103,8 @@ packages:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4752,7 +4753,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -4944,7 +4945,7 @@ snapshots:
       find-up: 5.0.0
       glob: 8.1.0
       he: 1.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 5.1.9
       ms: 2.1.3
@@ -4969,7 +4970,7 @@ snapshots:
 
   mute-stream@2.0.0: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   netmask@2.1.1: {}
 
@@ -5124,7 +5125,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,9 +15,14 @@ overrides:
   cookie@<0.7.0: ^0.7.0
   cross-spawn@<7.0.5: ^7.0.6
   esbuild@<0.25.0: ^0.25.0
-  js-yaml@<4.3.0: ^4.3.0
+  # GHSA-5p4m-2wfm-xmqj widened the !!omap quadratic-CPU advisory to cover
+  # 4.3.0, so the previous `<4.3.0: ^4.3.0` floor no longer clears it. 3.x is
+  # still swept up to 4.x on purpose: the fix was never backported there.
+  js-yaml@<4.3.1: ^4.3.1
   kysely@<0.28.17: ^0.28.17
   minimatch@<3.1.3: ^3.1.3
+  # GHSA-2v37-7h3g-55p8, reached only through vite > postcss at build time.
+  nanoid@<3.3.17: ^3.3.17
   serialize-javascript@<7.0.5: ^7.0.5
   tar-fs@>=2.0.0 <2.1.4: ^2.1.4
   tmp@<0.2.6: ^0.2.6


### PR DESCRIPTION
## Why master is red

The `Frontend (svelte-check)` job has been failing on `master` and on all five open Dependabot PRs. The failing step is `pnpm audit --ignore-registry-errors`, not `svelte-check` itself — the same single job, same single cause, everywhere.

`GHSA-5p4m-2wfm-xmqj` widened the js-yaml `!!omap` quadratic-CPU advisory to cover **4.3.0** — exactly the version our existing floor pinned to:

```yaml
js-yaml@<4.3.0: ^4.3.0   # resolves to 4.3.0, which is now itself vulnerable
```

So the override kept doing its job mechanically while silently ceasing to clear the advisory it was written for. Raised to `^4.3.1`. `nanoid` (`GHSA-2v37-7h3g-55p8`) surfaced the same way and gets a matching floor.

## Exposure: none

Neither package ships. The production tree is five packages:

```
@tauri-apps/api, @tauri-apps/plugin-clipboard-manager, @tauri-apps/plugin-opener
```

- **js-yaml** → `@wdio/mocha-framework > mocha > js-yaml`, the E2E test runner.
- **nanoid** → `vite > postcss > nanoid`, build-time only.

Both are dev-only, confirmed by `pnpm ls --prod`. The shipped Tauri binary and the built frontend bundle contain neither. **This is a CI gate repair, not a security fix — no redeploy is warranted.** Flagging that explicitly so it doesn't read as a security release and trigger a pull-to-update round for nothing.

Committed as `chore(deps)` rather than `fix` for the same reason: it should not mint a release implying a user-facing fix.

## Verified locally

| Check | Result |
|---|---|
| `pnpm audit` | No known vulnerabilities found |
| `pnpm run check` | 1248 files, 0 errors, 0 warnings |
| `pnpm test` | 213 passed (18 files) |
| `pnpm run build` | built |

Resolved: `js-yaml@4.3.1`, `nanoid@3.3.18`. Production tree unchanged at 5 packages — verified the raised floors did not disturb any direct dependency. The lockfile diff is 19 lines, no reserialization.

Once this lands, the five Dependabot PRs need a rebase to pick up the fixed lockfile and should go green on their own.