### PR TITLE
chore: move the toolchain to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.19.0",
   "description": "Client desktop moderne pour Vaultwarden/Bitwarden",
   "type": "module",
-  "packageManager": "pnpm@10.34.5",
+  "packageManager": "pnpm@11.21.0",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,3 +34,15 @@ overrides:
   undici@>=8.0.0 <8.9.0: ^8.9.0
   uuid@<14.0.0: ^14.0.0
   ws@<8.21.0: ^8.21.0
+
+# pnpm 11 turned "ignored build scripts" from a warning into a hard install
+# error, so the answer has to be recorded explicitly or `pnpm install
+# --frozen-lockfile` exits 1. All three were already unbuilt under pnpm 10 and
+# the full suite passes that way, so `false` records the status quo rather than
+# granting new postinstall execution — the safer default for a password
+# manager. Do not let pnpm write this block itself: it emits placeholder
+# strings and prepends them above this file's header comment.
+allowBuilds:
+  edgedriver: false
+  esbuild: false
+  geckodriver: false


### PR DESCRIPTION
## Scope

`pnpm/action-setup@v6` is used without a pinned `version:`, so it reads `packageManager` from `package.json`. This single field moves **all five workflows** — CI, CodeQL, dev-build and release — onto pnpm 11.21.0.

The lockfile is deliberately **untouched**. pnpm 11 accepts the existing `lockfileVersion: '9.0'` as-is (verified), so this stays a toolchain bump and nothing else. See "Why no lockfile refresh" below.

## Two behaviour changes had to be handled

**1. Ignored build scripts are now a hard error.** Under pnpm 10 these were a warning box; under pnpm 11 `pnpm install --frozen-lockfile` exits 1 with `ERR_PNPM_IGNORED_BUILDS`. The answer must be recorded explicitly. `edgedriver`, `esbuild` and `geckodriver` were already unbuilt under pnpm 10 and the full suite passes that way, so `allowBuilds: false` **records the status quo** rather than granting postinstall execution we never had — the safer reading for a password manager.

Worth knowing: pnpm will write this block itself if you let it, but it emits literal `set this to true or false` placeholders and prepends them *above* the file's header comment. It is hand-written here for that reason.

**2. A 24h supply-chain quarantine is now on by default.** `minimumReleaseAge` defaults to 1440 minutes and rejects any lockfile entry published inside that window. It gates **every `pnpm <script>` run**, not just install, because pnpm 11 re-verifies deps before running scripts.

Keeping that default is intentional. Compromised npm releases are typically detected and yanked within hours, so a 24h hold is a genuine defence for a project of this kind.

## ⚠️ CI is expected red until 2026-08-11 ~05:38 UTC

Two transitive entries that landed with this morning's Dependabot merges are still inside the quarantine window:

| Package | Published | Clears |
|---|---|---|
| `ip-address@10.5.0` | 2026-08-10 05:37 UTC | 2026-08-11 05:38 UTC |
| `tsx@4.23.12` | 2026-08-10 03:39 UTC | 2026-08-11 03:39 UTC |

This is the policy working as designed, not a defect in the bump. **Re-run CI after 2026-08-11 05:38 UTC and it goes green with no code change.** Do not merge before then.

## Why no lockfile refresh

`pnpm clean --lockfile && pnpm install` does resolve the quarantine immediately — pnpm 11 re-resolves to `ip-address@10.4.0` and `tsx@4.23.11`, and installs cleanly under the default policy. It was rejected anyway: that rebuild changed **79 package versions across 940 lockfile lines**. Shipping that under a "bump pnpm" heading would make both halves unreviewable and would make a later regression impossible to attribute — pnpm 11, or one of 79 dependency moves? Waiting ~21h costs nothing and keeps the diff to two files.

## Verified locally under pnpm 11.21.0

| Check | Result |
|---|---|
| `pnpm audit --prod` | No known vulnerabilities found |
| `pnpm audit` (full tree) | No known vulnerabilities found |
| `pnpm check` | 0 errors, 0 warnings |
| `pnpm test` | 213 passed (18 files) |
| `pnpm build` | OK |

Script runs were exercised with `--config.verifyDepsBeforeRun=false` to step over the quarantine gate described above; nothing else was relaxed, and no config was written to the repo.

## One local-only note

pnpm 11 refuses to recreate `node_modules` without a TTY (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`) when the directory was built by pnpm 10. CI is unaffected — it sets `CI` and checks out fresh — but locally the first install after this lands needs `CI=true pnpm install` or `confirmModulesPurge=false`.