### PR TITLE
chore(ci): watch unmaintained/unsound advisories, correct the brace-expansion note

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,18 +106,33 @@ jobs:
         with:
           tool: cargo-audit
 
-      # RUSTSEC-2023-0071 : Marvin Attack sur le crate `rsa` (timing side-channel
-      # sur le déchiffrement RSA-OAEP). Pas de fix upstream disponible à ce jour.
-      # Notre exposition est faible : déchiffrement d'org keys une fois par sync,
-      # HTTPS vers Vaultwarden, pas d'oracle exposé à un attaquant. À retirer dès
-      # que le crate `rsa` publie une version constant-time (0.10 n'existe
-      # toujours qu'en release candidate).
+      # Les advisories tolérées vivent désormais dans src-tauri/.cargo/audit.toml
+      # (lu depuis le CWD, donc depuis src-tauri grâce au working-directory du
+      # job), une par ligne avec sa justification — y compris RUSTSEC-2023-0071
+      # sur `rsa`, qui était jusqu'ici le seul `--ignore` de cette étape. Le
+      # fichier vaut mieux que le flag pour une raison précise : le flag
+      # n'existait que dans ce workflow, si bien qu'un `cargo audit` lancé à la
+      # main dans src-tauri affichait « 1 vulnerability found! » sur un arbre que
+      # la CI déclarait vert.
+      #
+      # `--deny unmaintained --deny unsound` est la vraie nouveauté. Sans ces
+      # flags, `cargo audit` n'échoue que sur les vulnérabilités : les 20
+      # advisories unmaintained/unsound de l'arbre défilaient sous la forme
+      # « 21 allowed warnings found » et personne ne les regardait. Un nouveau
+      # crate non maintenu se serait fondu dans le lot sans rien déclencher.
+      # Maintenant, tout ce qui n'est pas explicitement listé dans audit.toml
+      # fait rougir le job.
+      #
+      # `yanked` est délibérément absent des `--deny` : spin 0.9.8 est yanked
+      # via ring, et un crate yanked n'a pas d'identifiant RUSTSEC — il est donc
+      # impossible de l'allowlister. Le dénier figerait le job au rouge sans
+      # rien apprendre. Voir la note en fin d'audit.toml.
       #
       # RUSTSEC-2026-0194 / RUSTSEC-2026-0195 (`quick-xml` < 0.41.0) ne sont plus
       # ignorés : `wayland-scanner` 0.31.11 est passé à `quick-xml` ^0.41, donc
       # plus aucune copie vulnérable dans l'arbre.
       - name: cargo audit
-        run: cargo audit --ignore RUSTSEC-2023-0071
+        run: cargo audit --deny unmaintained --deny unsound
 
   frontend:
     name: Frontend (svelte-check)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,22 @@ overrides:
   # three: 1.1.18 and 2.1.4.
   # Do NOT collapse these into `brace-expansion@<5.0.8: ^5.0.8`: 5.x exports
   # `{ expand }` instead of the callable default, so every minimatch <= 6 dies
-  # with "expand is not a function". Only minimatch >= 9.0.6 speaks that API,
-  # and getting there means moving @wdio off v7 — see the follow-up issue.
+  # with "expand is not a function". Only minimatch >= 9.0.6 speaks that API.
+  #
+  # This used to say the way out was "moving @wdio off v7 — see the follow-up
+  # issue". Both halves were wrong: every @wdio/* in the tree is already on
+  # v9, and no such issue was ever opened. The three minimatch lines are all
+  # transitives *underneath* wdio v9, and none of them is ours to move:
+  #   minimatch 3.1.5 <- glob@7 <- rimraf@3 <- puppeteer-core@13.7.0 (2022)
+  #                       <- webdriverio; and <- recursive-readdir <- create-wdio
+  #   minimatch 5.1.9 <- glob@8 <- mocha@10 <- @wdio/mocha-framework;
+  #                       <- filelist <- jake <- ejs <- create-wdio;
+  #                       <- readdir-glob <- archiver <- webdriverio
+  #   minimatch 9.0.9 <- glob@10 <- @wdio/config   (this one would take 5.x)
+  # So there is no upgrade to chase and nothing to track. The floors below
+  # are the fix, not a stopgap. They can go the day webdriverio drops
+  # puppeteer-core@13 and mocha moves off glob@8 — check with
+  # `pnpm why minimatch`, and only then.
   brace-expansion@<1.1.18: ^1.1.18
   brace-expansion@>=2.0.0 <2.1.4: ^2.1.4
   cookie@<0.7.0: ^0.7.0

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -1,0 +1,76 @@
+# cargo-audit configuration. Read from `$CWD/.cargo/audit.toml`, and the
+# Rust CI job runs with `working-directory: src-tauri` — so this file also
+# applies when you run `cargo audit` by hand from src-tauri/, which is the
+# point: local and CI now agree instead of local showing failures CI hides.
+#
+# Why a file rather than `--ignore` flags on the CI step: the flags only
+# existed in ci.yml, so a developer running `cargo audit` locally saw
+# "error: 1 vulnerability found!" on a tree CI called green. (cargo-audit's
+# `--ignore` is otherwise sound — unlike pnpm's, it filters at runtime,
+# writes nothing, and still exits 1 if a live advisory remains. It was not
+# a correctness problem, only a local/CI divergence.)
+#
+# Every id below is EXPECTED and reviewed. The CI step denies unmaintained
+# and unsound advisories, so anything NOT listed here turns the build red —
+# that is the whole purpose. Do not add an id without a reason on the line.
+# Re-check the list with:
+#   cargo audit --file src-tauri/Cargo.lock --json | jq '.warnings'
+
+[advisories]
+ignore = [
+  # -- vulnerability -------------------------------------------------------
+  # Marvin Attack: timing side-channel in RSA-OAEP decryption. No upstream
+  # fix exists (rsa 0.10 is still only a release candidate). Our exposure is
+  # low: org keys are decrypted once per sync, over HTTPS to Vaultwarden,
+  # with no oracle reachable by an attacker. Drop this the day `rsa` ships a
+  # constant-time release.
+  "RUSTSEC-2023-0071",
+
+  # -- unmaintained: gtk-rs GTK3 bindings ----------------------------------
+  # Ten crates, one upstream decision: the gtk-rs project stopped
+  # maintaining its GTK3 bindings. They reach us through Tauri's Linux
+  # webview stack, not from our own Cargo.toml, so there is nothing to
+  # migrate on our side until Tauri moves to GTK4.
+  "RUSTSEC-2024-0411", # gdkwayland-sys
+  "RUSTSEC-2024-0412", # gdk
+  "RUSTSEC-2024-0413", # atk
+  "RUSTSEC-2024-0414", # gdkx11-sys
+  "RUSTSEC-2024-0415", # gtk
+  "RUSTSEC-2024-0416", # atk-sys
+  "RUSTSEC-2024-0417", # gdkx11
+  "RUSTSEC-2024-0418", # gdk-sys
+  "RUSTSEC-2024-0419", # gtk3-macros
+  "RUSTSEC-2024-0420", # gtk-sys
+
+  # -- unmaintained: misc transitives --------------------------------------
+  "RUSTSEC-2024-0370", # proc-macro-error, via the derive-macro chain
+  "RUSTSEC-2025-0057", # fxhash
+
+  # -- unmaintained: unic-* ------------------------------------------------
+  # The unic crates are pulled in for IDNA/Unicode handling underneath the
+  # HTTP stack. Unmaintained, but pure lookup-table code with no known
+  # defect.
+  "RUSTSEC-2025-0075", # unic-char-range
+  "RUSTSEC-2025-0080", # unic-common
+  "RUSTSEC-2025-0081", # unic-char-property
+  "RUSTSEC-2025-0098", # unic-ucd-version
+  "RUSTSEC-2025-0100", # unic-ucd-ident
+
+  # -- unsound -------------------------------------------------------------
+  # `!Send` tags crossing a thread boundary via StackSlot. Transitive under
+  # the async runtime; we never construct the affected StackSlot ourselves.
+  "RUSTSEC-2026-0221", # event-listener
+  # Unsound Iterator impls for glib::VariantStrIter. Same GTK3 stack as
+  # above; we do not use VariantStrIter.
+  "RUSTSEC-2024-0429", # glib
+  # Unsound only when a custom logger calls rand::rng() reentrantly. We
+  # install no such logger.
+  "RUSTSEC-2026-0097", # rand
+]
+
+# NOT denied in CI: `yanked`. spin 0.9.8 is yanked and reaches us through
+# ring, and a yanked crate carries no RUSTSEC id — so there is no way to
+# allowlist it here. Adding `--deny yanked` to the CI step would therefore
+# pin the job red permanently rather than tell us anything new. It still
+# shows up as "1 allowed warning found" in the job log. Revisit if ring
+# ever bumps its spin requirement.


### PR DESCRIPTION
Two findings from the triage follow-up, both about audit gates telling the truth.

## 1. Nobody was watching the warnings

`cargo audit` only fails on *vulnerabilities*. The 20 `unmaintained`/`unsound` advisories in the tree went by as a single line — `21 allowed warnings found` — and nothing gated on them. A crate going newly-unmaintained would have blended into that pile without turning anything red.

The step now runs `--deny unmaintained --deny unsound` against an explicit allowlist in `src-tauri/.cargo/audit.toml`, one id per line with its reason. **Anything not on the list fails the job.**

Verified three ways — each takes the step from exit 0 to exit 1:

| Simulated event | Result |
|---|---|
| New `unsound` (dropped `RUSTSEC-2026-0097`, rand) | **exit 1** |
| New `unmaintained` (dropped `RUSTSEC-2024-0415`, gtk) | **exit 1** |
| Real vulnerability (dropped `RUSTSEC-2023-0071`, rsa) | **exit 1** |
| Full list, as committed | exit 0 — noise down from 21 warnings to 1 |

The list matches the tree exactly: 21 ids, no duplicates, none missing, none stale.

**`yanked` is deliberately not denied.** `spin` 0.9.8 is yanked via `ring`, and a yanked crate carries **no RUSTSEC id** — so it cannot be allowlisted. Denying it would pin the job red permanently without saying anything new. It stays visible as `1 allowed warning found`.

### Bonus: a local/CI divergence closed

The `rsa` ignore moved from the CI flag into `audit.toml`. The flag lived only in `ci.yml`, so `cargo audit` run by hand in `src-tauri` printed `error: 1 vulnerability found!` on a tree CI called green — good way to lose an afternoon.

To be clear, this is **not** the pnpm trap: cargo-audit's `--ignore` filters at runtime, writes nothing, and still exits 1 on a live advisory. Verified. It was a parity problem, not a correctness one.

## 2. The brace-expansion note was misleading

It said the way out of the double floor was *"moving @wdio off v7 — see the follow-up issue"*. Both halves are wrong:

- **Every `@wdio/*` in the tree is already on v9.** There is no v7.
- **No such issue exists** — the repo has zero open issues, and the four referenced elsewhere (#24, #25, #147, #245) are all closed or merged.

The old minimatch copies are transitives *underneath* wdio v9, none of them ours to move:

```
minimatch 3.1.5 <- glob@7  <- rimraf@3 <- puppeteer-core@13.7.0 (2022) <- webdriverio
                <- recursive-readdir <- create-wdio
minimatch 5.1.9 <- glob@8  <- mocha@10 <- @wdio/mocha-framework
                <- filelist <- jake <- ejs <- create-wdio
                <- readdir-glob <- archiver <- webdriverio
minimatch 9.0.9 <- glob@10 <- @wdio/config          (this one would take 5.x)
```

So there is no upgrade to chase and nothing to track — **the floors are the fix, not a stopgap**. The comment now carries the real chains and the real condition for removing them (`pnpm why minimatch`, once webdriverio drops puppeteer-core@13 and mocha moves off glob@8), so nobody goes hunting a migration that does not exist.

No override was touched: `pnpm audit` full and prod trees both still exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R53joBS8knRMo9dbB6L2Ky