### PR TITLE
chore(ci): watch yanked crates and guard the required-check names

### DIFF
--- a/.github/required-checks.txt
+++ b/.github/required-checks.txt
@@ -1,0 +1,28 @@
+# Status checks required by master's branch protection.
+#
+# This file is the source of truth. Branch protection on GitHub must list
+# exactly these names - re-apply it from here with:
+#
+#   jq -Rn '[inputs | select(startswith("#") or . == "" | not)]' \
+#     .github/required-checks.txt \
+#   | jq '{required_status_checks: {strict: false, contexts: .},
+#          enforce_admins: true, required_pull_request_reviews: null,
+#          restrictions: null, allow_force_pushes: false,
+#          allow_deletions: false}' \
+#   | gh api -X PUT repos/Upellift99/clavix/branches/master/protection --input -
+#
+# WHY THIS FILE EXISTS: a required check is matched by NAME. Rename a job in
+# a workflow and its old name stays required, never reports, and every PR is
+# blocked on a check that can no longer run - with nothing explaining why.
+# scripts/check-required-checks.sh runs in CI and fails the moment a name
+# here stops matching a real job, so the rename breaks loudly and early
+# instead of silently wedging the queue.
+#
+# Renaming a job therefore means: update the workflow, update this file, and
+# re-apply protection with the command above - in the same change.
+
+Rust (fmt + clippy + audit)
+Frontend (svelte-check)
+E2E (Tauri + WebdriverIO)
+Smoke E2E (release build)
+Analyze (javascript-typescript)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,15 @@ jobs:
       - name: cargo audit
         run: cargo audit --deny unmaintained --deny unsound
 
+      # The `yanked` category the step above deliberately does not deny (see
+      # the note there). Denying it is impossible without pinning the job red,
+      # so this pins the exact SET of yanked crates instead: the one we know
+      # about passes, anything new fails. Runs from the repo root rather than
+      # src-tauri because the script resolves its own default lockfile path.
+      - name: Yanked crates match the baseline
+        working-directory: .
+        run: ./scripts/check-yanked-crates.sh
+
   frontend:
     name: Frontend (svelte-check)
     runs-on: ubuntu-24.04
@@ -141,6 +150,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Cheap and dependency-free, so it goes first: if a required check no
+      # longer names a real job, say so before spending ten minutes on the
+      # rest. Lives in this job (rather than one of its own) so it does not
+      # add a sixth check name that would itself have to be required.
+      - name: Required checks still name real jobs
+        run: ./scripts/check-required-checks.sh
 
       - name: Install pnpm
         uses: pnpm/action-setup@v6

--- a/scripts/check-required-checks.sh
+++ b/scripts/check-required-checks.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Fail if a name in .github/required-checks.txt no longer matches a job that
+# the workflows can actually produce.
+#
+# The failure this prevents: branch protection matches required checks by
+# NAME. Rename a job and the old name stays required but never reports, so
+# every PR sits blocked on "Expected - waiting for status" from a job that no
+# longer exists. Nothing in the UI says why. Here the rename fails CI on the
+# very PR that makes it, with the two names side by side.
+#
+# This deliberately checks the workflows, not the live protection settings:
+# reading branch protection needs an admin-scoped token, and GITHUB_TOKEN
+# does not have one. So it catches "job renamed, file not updated" - the
+# direction that actually bites. Keeping the file and GitHub in step is the
+# job of the re-apply command documented in required-checks.txt.
+#
+# Usage: scripts/check-required-checks.sh
+
+set -euo pipefail
+
+LIST=".github/required-checks.txt"
+WORKFLOWS=".github/workflows"
+
+[ -f "$LIST" ] || { echo "::error::$LIST not found."; exit 1; }
+
+fail=0
+checked=0
+
+while IFS= read -r name; do
+  # Skip blanks and comments.
+  case "$name" in ''|'#'*) continue ;; esac
+  checked=$((checked + 1))
+
+  # Most jobs carry the name literally, e.g. `name: Frontend (svelte-check)`.
+  if grep -rqF "name: $name" "$WORKFLOWS"; then
+    continue
+  fi
+
+  # CodeQL builds its name from the matrix: `name: Analyze (${{ matrix.language }})`
+  # expands to `Analyze (javascript-typescript)`. Accept that when both the
+  # templated prefix and the matrix value are present.
+  prefix="${name%% (*}"
+  value="${name#*(}"
+  value="${value%)}"
+  if [ "$prefix" != "$name" ] \
+     && grep -rqF "name: $prefix (\${{ matrix." "$WORKFLOWS" \
+     && grep -rqF "$value" "$WORKFLOWS"; then
+    continue
+  fi
+
+  echo "::error::Required check '$name' matches no job in $WORKFLOWS/."
+  fail=1
+done < "$LIST"
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "A required check must name a job that still exists. If you renamed a"
+  echo "job, update $LIST too, then re-apply branch protection with the"
+  echo "command in that file's header - otherwise every PR will block on a"
+  echo "check that can never report."
+  exit 1
+fi
+
+echo "All $checked required checks match a job in $WORKFLOWS/."

--- a/scripts/check-yanked-crates.sh
+++ b/scripts/check-yanked-crates.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Watch for newly-yanked crates.
+#
+# `cargo audit --deny yanked` is not usable here: a yanked crate carries no
+# RUSTSEC id, so it cannot be listed in audit.toml's `ignore`. Adding the flag
+# would pin the Rust job red forever on the one yanked crate we already know
+# about, and a permanently-red gate is a gate nobody reads.
+#
+# So instead of denying the category, we pin the exact set. Any yanked crate
+# that is not in BASELINE below fails the build; the known one does not.
+#
+# When this fails, either the new crate is genuinely a problem (bump whatever
+# pulls it) or it is another one we must live with (add it here, with the
+# reason). Do not silence it by emptying the check.
+#
+# Usage: scripts/check-yanked-crates.sh [path/to/Cargo.lock]
+
+set -euo pipefail
+
+LOCKFILE="${1:-src-tauri/Cargo.lock}"
+
+# name<TAB>version, one per line, sorted. Keep the reason next to each entry.
+#
+# spin 0.9.8: reached through lazy_static 1.5.0's `spin_no_std` feature, which
+# num-bigint-dig, x509-parser and zxcvbn all pull in. Not ours to move, and
+# lazy_static 1.5.0 is already its final release. (It does NOT come from
+# `ring`, which dropped its spin dependency in 0.17.)
+read -r -d '' BASELINE <<'EOF' || true
+spin	0.9.8
+EOF
+
+# cargo audit's exit code is the *other* gate's business - it is non-zero
+# whenever any advisory is outstanding, and it also depends on whether
+# .cargo/audit.toml is on the path from the current directory. We only want
+# the yanked list out of the JSON, so take the report and ignore the status.
+report="$(cargo audit --file "$LOCKFILE" --json 2>/dev/null || true)"
+
+if [ -z "$report" ]; then
+  echo "::error::cargo audit produced no report for $LOCKFILE (is cargo-audit installed?)."
+  exit 1
+fi
+
+actual="$(printf '%s' "$report" \
+  | jq -r '(.warnings.yanked // [])[] | "\(.package.name)\t\(.package.version)"' \
+  | sort)"
+
+expected="$(printf '%s\n' "$BASELINE" | sed '/^$/d' | sort)"
+
+if [ "$actual" = "$expected" ]; then
+  count="$(printf '%s\n' "$expected" | sed '/^$/d' | wc -l)"
+  echo "Yanked crates match the baseline ($count known)."
+  exit 0
+fi
+
+echo "::error::The set of yanked crates changed."
+echo
+echo "--- expected (baseline in $0) ---"
+printf '%s\n' "$expected"
+echo "--- actual (from $LOCKFILE) ---"
+printf '%s\n' "$actual"
+echo
+echo "New entries mean a dependency was yanked upstream: bump whatever pulls"
+echo "it, or add it to BASELINE with the reason. Entries that disappeared are"
+echo "good news - remove them from BASELINE to keep the check meaningful."
+exit 1

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -68,9 +68,15 @@ ignore = [
   "RUSTSEC-2026-0097", # rand
 ]
 
-# NOT denied in CI: `yanked`. spin 0.9.8 is yanked and reaches us through
-# ring, and a yanked crate carries no RUSTSEC id — so there is no way to
-# allowlist it here. Adding `--deny yanked` to the CI step would therefore
-# pin the job red permanently rather than tell us anything new. It still
-# shows up as "1 allowed warning found" in the job log. Revisit if ring
-# ever bumps its spin requirement.
+# NOT denied in CI: `yanked`. A yanked crate carries no RUSTSEC id, so there
+# is no way to allowlist one here, and `--deny yanked` would pin the job red
+# permanently on spin 0.9.8 rather than tell us anything new.
+#
+# That category is not left unwatched, though: scripts/check-yanked-crates.sh
+# pins the exact SET of yanked crates, so a newly-yanked dependency fails CI
+# while the known one does not. Update its baseline, not this file.
+#
+# (An earlier version of this note said spin arrives via `ring`. That was
+# wrong - ring dropped its spin dependency in 0.17. It actually comes from
+# lazy_static 1.5.0's `spin_no_std` feature, pulled in by num-bigint-dig,
+# x509-parser and zxcvbn.)


### PR DESCRIPTION
Closes the two gaps I left open in #259 — and fixes a claim I got wrong there.

## 1. Yanked crates were the last unwatched category

They cannot be denied. A yanked crate carries **no RUSTSEC id**, so it cannot go in `audit.toml`'s `ignore`, and `--deny yanked` would pin the Rust job red forever on `spin` 0.9.8. A permanently-red gate is a gate nobody reads.

So `scripts/check-yanked-crates.sh` pins the exact **set** instead: the known one passes, anything newly yanked fails.

| Scenario | Result |
|---|---|
| Tree as committed | exit 0 — `Yanked crates match the baseline (1 known).` |
| Baseline emptied (simulates a new yanked crate) | **exit 1** |
| Baseline changed to `spin 0.9.7` (simulates a version change) | **exit 1**, prints both sets side by side |

One subtlety worth recording: the script takes `cargo audit`'s JSON but **ignores its exit code**, which is the other gate's business — it is non-zero whenever any advisory is outstanding, and it also depends on whether `.cargo/audit.toml` is on the path from the current directory. Wiring those together made the first version die silently under `pipefail`.

## 2. The job-rename footgun we created

With `enforce_admins` on, renaming a CI job leaves its old name required, never reporting, blocking **every** PR on a check that cannot run — and nothing in the UI says why.

`.github/required-checks.txt` is now the source of truth, and `scripts/check-required-checks.sh` fails the moment a name stops matching a real job, so the rename breaks loudly on the PR that makes it.

| Scenario | Result |
|---|---|
| Current state | exit 0 — all 5 match |
| Literal rename (`Frontend` → `Front`) | **exit 1**, names the check |
| CodeQL matrix change (`javascript-typescript` → `python`) | **exit 1** — the templated `Analyze (${{ matrix.language }})` case is handled |

It checks the **workflows**, not the live protection settings: reading branch protection needs an admin-scoped token and `GITHUB_TOKEN` has none. That still covers the direction that actually bites. The file's header carries the one-liner that re-applies protection from it — I ran it through `jq` and confirmed the output matches the live settings exactly.

It runs first in the Frontend job, before the ten minutes of install/build, and lives there rather than in a job of its own so it does not add a **sixth** check name that would itself need to be required.

## 3. A correction

`audit.toml` claimed `spin` arrives via `ring`. **It does not** — `ring` dropped its spin dependency in 0.17. It comes from `lazy_static` 1.5.0's `spin_no_std` feature, pulled in by `num-bigint-dig`, `x509-parser` and `zxcvbn`. Corrected, and flagged as a correction so the next reader knows it was actually checked.

While verifying the rest: the GTK3 bindings really are entirely Tauri's own (`gtk` 0.18.2 under `tao`/`wry`/`webkit2gtk`/`muda`/`libappindicator`, nothing in our `Cargo.toml`), so that part of the allowlist genuinely waits on Tauri moving to GTK4, not on us.

No override touched — `pnpm audit` full and prod trees both still exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R53joBS8knRMo9dbB6L2Ky