### PR TITLE
chore(ci): record the 2026-08-17 cargo Dependabot stall and retry it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,29 @@ updates:
       - rust
     commit-message:
       prefix: "chore(deps-rust)"
+    # 2026-08-17: this job failed wholesale — all five candidate updates
+    # (thiserror, zbus, futures, rusqlite, ctap-hid-fido2) came back
+    # `dependency_file_not_resolvable`, every one of them on the same root
+    # message: "failed to select a version for the requirement
+    # `cpufeatures = ^0.3` (locked to 0.3.0) — candidate versions found
+    # which didn't match: 0.2.17, 0.2.16, ...".
+    #
+    # The repository was not at fault, and it is worth not re-deriving this:
+    # cpufeatures 0.3.0 is neither yanked nor missing (published 2026-02-05,
+    # still the crate's default version), aes 0.9.1 likewise (2026-05-27),
+    # and both have sat in Cargo.lock since 4cc9aa7 (2026-05-09) — content
+    # this very job resolved successfully every Monday through 2026-08-10.
+    # It does not reproduce locally on cargo 1.96, nor under a real 1.84
+    # toolchain, nor with `rust-version` forced down to 1.80, so it is not
+    # MSRV-aware resolution either. Only 0.2.x candidates being visible means
+    # the updater's index view lacked 0.3.0 — its proxy reported 79% cached
+    # calls that run. In short: a stale index cache on Dependabot's side.
+    #
+    # Editing this file makes Dependabot re-check the ecosystem, which is
+    # how the failure above was retried. If it ever comes back with the same
+    # message, do NOT edit Cargo.lock or chase the crate — confirm against
+    # crates.io first, then retry. Rust health while the bot is down is
+    # checked by hand with `cargo audit` (clean at the time of writing).
     # Ignore semver-major bumps for crates that depend on the same
     # `digest 0.10` / `rand_core 0.6` slice as `rsa 0.9` (our stable).
     # Bumping any one of them breaks the other six because `rsa` still


### PR DESCRIPTION
## Why

The weekly `cargo in /src-tauri` job failed wholesale on 2026-08-17: all five candidate updates (thiserror, zbus, futures, rusqlite, ctap-hid-fido2) came back `dependency_file_not_resolvable`, every one of them on the same root message —

> failed to select a version for the requirement `cpufeatures = "^0.3"` (locked to 0.3.0)
> candidate versions found which didn't match: 0.2.17, 0.2.16, 0.2.15, …

This is the only automation watching the Rust tree, so leaving it broken means nothing is watching the crates at all.

## What it is not

Checked rather than assumed, before touching anything:

- `cpufeatures 0.3.0` is **neither yanked nor missing** — published 2026-02-05, still the crate's default version, present in the index.
- `aes 0.9.1` likewise (published 2026-05-27).
- Both have been in `Cargo.lock` since 4cc9aa7 (2026-05-09), **content this same job resolved without complaint every Monday through 2026-08-10**.
- It does not reproduce on cargo 1.96, under a real 1.84 toolchain, or with `rust-version` forced down to 1.80 → not MSRV-aware resolution.
- `cargo audit --deny unmaintained --deny unsound` over 722 crates: no vulnerabilities, only the baselined `spin 0.9.8`. `scripts/check-yanked-crates.sh` passes.

Only 0.2.x versions being offered as candidates can mean one thing: the index the updater saw did not contain 0.3.0. Its proxy reported 79% of calls served from cache on that run. A stale index cache on Dependabot's side, in short.

## What this PR does

Editing this file makes Dependabot re-check the ecosystem, so **this commit doubles as the retry**, on top of recording the diagnosis where the next reader will look for it. The comment says explicitly not to edit `Cargo.lock` or chase the crate if it recurs.

**Comment-only change**: no key, value, `ignore` entry or group is touched — the diff adds only `#` lines and removes none.

## To watch after merge

That the next `cargo in /src-tauri` run goes green. If it replays the same error, it is a persistent updater bug rather than a cache, and the right move is to escalate rather than patch the repository.

Incidentally: the Rust tree drifted while the bot was down (~170 crates would move on a full `cargo update`, mostly transitive). Nothing vulnerable — but it is Dependabot's job to catch up once it is running again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pnoX5pomFTJcApXec7bhc