### PR TITLE
ci(release): build the release notes from the CHANGELOG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,64 @@ jobs:
             echo "value=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           fi
 
+      # `releaseBody` used to be a hardcoded string, so every release page said
+      # "Automated release built by GitHub Actions" and nothing about what the
+      # version contained — v0.17.0, v0.18.0 and v0.19.0 all shipped real
+      # features behind that same blurb, and v0.19.1's notes had to be patched
+      # by hand after publication.
+      #
+      # Note this is NOT the usual release-please arrangement: tauri-action
+      # creates the release itself and writes its own body, so enriching the
+      # release PR body changes nothing a user ever sees. The CHANGELOG is the
+      # only text that reaches them, hence reading it here.
+      #
+      # Runs on all three matrix runners, so it must be deterministic: the body
+      # is a pure function of the tag and the checked-out CHANGELOG, which are
+      # identical everywhere, so whichever runner creates the release first
+      # writes the same text the other two would have.
+      - name: Compose the release notes from the CHANGELOG
+        id: notes
+        shell: bash
+        run: |
+          version="${{ steps.tag.outputs.value }}"
+          version="${version#v}"
+
+          # Everything between this version's `## [x.y.z]` heading and the next
+          # one, with the leading blank lines release-please emits dropped.
+          section="$(awk -v v="$version" '
+            index($0, "## [" v "]") == 1 { inside = 1; next }
+            inside && index($0, "## [") == 1 { exit }
+            inside { if (!started && $0 ~ /^[[:space:]]*$/) next; started = 1; print }
+          ' CHANGELOG.md)"
+
+          # No entry is not an error: a workflow_dispatch re-run can name a tag
+          # this checkout has no section for. Say less rather than lie.
+          if [ -z "$section" ]; then
+            echo "::warning::No CHANGELOG section for $version; publishing the artifact legend only."
+            section="See the CHANGELOG for what this version contains."
+          fi
+
+          # Emitted line by line rather than from a heredoc on purpose: heredoc
+          # bodies sit at column 0, which ends this YAML block scalar early —
+          # and a bare `---` there parses as a document separator, silently
+          # cutting every later step out of the workflow.
+          {
+            echo "body<<CLAVIX_RELEASE_NOTES_EOF"
+            printf '%s\n' "$section"
+            echo
+            echo "---"
+            echo
+            echo "Automated release built by GitHub Actions."
+            echo
+            echo "Artifacts :"
+            echo "- \`.AppImage\` : portable Linux binary, double-click to run"
+            echo "- \`.deb\` : Debian / Ubuntu package (\`sudo dpkg -i\`)"
+            echo "- \`.rpm\` : Fedora / openSUSE package"
+            echo "- \`.dmg\` / \`.app.tar.gz\` : macOS (universal)"
+            echo "- \`.msi\` / \`-setup.exe\` : Windows (x64)"
+            echo "CLAVIX_RELEASE_NOTES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and bundle with tauri-action
         uses: tauri-apps/tauri-action@v1
         env:
@@ -102,13 +160,7 @@ jobs:
         with:
           tagName: ${{ steps.tag.outputs.value }}
           releaseName: "Clavix ${{ steps.tag.outputs.value }}"
-          releaseBody: |
-            Automated release built by GitHub Actions.
-
-            Artifacts :
-            - `.AppImage` : portable Linux binary, double-click to run
-            - `.deb` : Debian / Ubuntu package (`sudo dpkg -i`)
-            - `.rpm` : Fedora / openSUSE package
+          releaseBody: ${{ steps.notes.outputs.body }}
           releaseDraft: false
           prerelease: false
           args: ${{ matrix.tauri-target }}


### PR DESCRIPTION
## The problem

`releaseBody` was a hardcoded string, so **every release page said "Automated release built by GitHub Actions" and nothing about the version**. v0.17.0, v0.18.0 and v0.19.0 all shipped real features behind that same blurb, and v0.19.1's notes had to be patched by hand after publication.

## Why it was not obvious

This is **not** the usual release-please arrangement. `tauri-action` creates the release itself and writes its own body, so enriching the release PR body — the thing that normally becomes the notes — changes nothing a user ever sees. The CHANGELOG is the only prose that reaches them, hence reading it here.

## What the step does

Lifts the section between this version's `## [x.y.z]` heading and the next one, then appends the artifact legend.

It runs on all three matrix runners, so it has to be deterministic: the body is a pure function of the tag and the checked-out CHANGELOG, both identical everywhere, so whichever runner creates the release first writes the text the other two would have written.

**A missing section is not an error.** A `workflow_dispatch` re-run can name a tag this checkout has no entry for; it emits a `::warning::` and falls back to pointing at the CHANGELOG — saying less rather than something false.

The legend also gains the **macOS and Windows lines it never had**: the release ships seven artifacts and the list only ever described three.

## Two traps, left as comments in the file

1. The notes are emitted with `echo` per line rather than from a heredoc. A heredoc body sits at column 0, which **terminates the YAML block scalar early** — and a bare `---` there parses as a **document separator**, which silently cut `tauri-action` and the artifact-upload step out of the workflow entirely. I hit this on the first attempt; it was caught by parsing the file and counting steps, not by reading it.
2. `releaseDraft: false` is load-bearing on this repo and is untouched.

## Verified

- The step's `run:` was **extracted from the parsed YAML and executed**, not retyped: `v0.19.1` reproduces the notes now published on that release, backticks intact.
- A nonexistent tag takes the fallback and emits the warning.
- The workflow parses as **exactly one document with all 11 steps**; `tauri-action` is present with `releaseBody: ${{ steps.notes.outputs.body }}`, `releaseDraft: false`, `prerelease: false`.

## Note on scope

This changes nothing until the next tag. The first release cut after this merges is the real proof — worth a glance at its page when it happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pnoX5pomFTJcApXec7bhc